### PR TITLE
Add XLNet in list of models for `run_glue_tpu.py`

### DIFF
--- a/examples/run_glue_tpu.py
+++ b/examples/run_glue_tpu.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Finetuning the library models for sequence classification on GLUE (Bert)."""
+""" Finetuning the library models for sequence classification on GLUE (Bert, XLNet)."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -62,10 +62,11 @@ from transformers import glue_convert_examples_to_features as convert_examples_t
 logger = logging.getLogger(__name__)
 script_start_time = time.strftime("%Y%m%d_%H%M%S", time.gmtime())
 
-ALL_MODELS = sum((tuple(conf.pretrained_config_archive_map.keys()) for conf in (BertConfig,)), ())
+ALL_MODELS = sum((tuple(conf.pretrained_config_archive_map.keys()) for conf in (BertConfig, XLNetConfig)), ())
 
 MODEL_CLASSES = {
     'bert': (BertConfig, BertForSequenceClassification, BertTokenizer),
+    'xlnet': (XLNetConfig, XLNetForSequenceClassification, XLNetTokenizer),
 }
 
 


### PR DESCRIPTION
Testing done for both `xlnet-base-cased` and `xlnet-large-cased` on performance and convergence with `v3-8`.