### PR TITLE
Update device count API

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -474,7 +474,7 @@ def main():
     import torch_xla.core.xla_model as xm
     import torch_xla.experimental.xla_sharding as xs
     import torch_xla.runtime as xr
-    num_devices = xr.global_device_count()
+    num_devices = xr.global_runtime_device_count()
     device_ids = torch.arange(num_devices)
     print('Using dtype', model_args.torch_dtype)
     model = model.to(xm.xla_device(), dtype=getattr(torch, model_args.torch_dtype))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1453,7 +1453,7 @@ class Trainer:
             import torch_xla.experimental.xla_sharding as xs
             import torch_xla.runtime as xr
             import torch_xla.distributed.parallel_loader as pl
-            num_devices = xr.global_device_count()
+            num_devices = xr.global_runtime_device_count()
             device_ids = np.arange(num_devices)
 
             sharding_spec = None


### PR DESCRIPTION
The Python device API was updated in https://github.com/pytorch/xla/pull/5129. We need to use the latest APIs for the nightly build.