### PR TITLE
Disable checkpoint writing

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2800,6 +2800,8 @@ class Trainer:
             self.push_to_hub(commit_message="Model save")
 
     def _save_tpu(self, output_dir: Optional[str] = None):
+        #TODO(jonbolin): Re-enable
+        return
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         logger.info(f"Saving model checkpoint to {output_dir}")
 
@@ -2828,6 +2830,8 @@ class Trainer:
             self.tokenizer.save_pretrained(output_dir)
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
+        #TODO(jonbolin): Re-enable
+        return
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
The standard HF checkpoint mechanism will require us to all-gather every parameter on a single host using `ReplicateShardedData`, which requires compiling and executing a computation for each param.

This change disables checkpointing.