### PR TITLE
Add flag for iota mesh

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -243,6 +243,7 @@ class LlamaAttention(nn.Module):
         # For PyTorch/XLA's SPMD 2D sharding
         self.spmd_2d_sharding = config.spmd_2d_sharding
         self.spmd_debug = config.spmd_debug
+        self.spmd_iota_mesh = config.spmd_iota_mesh
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.head_dim = self.hidden_size // self.num_heads
@@ -387,8 +388,12 @@ class LlamaAttention(nn.Module):
             model = self.spmd_2d_sharding
             data = num_devices // model
             assert model * data == num_devices
-            data_model_mesh = xs.HybridMesh(ici_mesh_shape=(data, 1, model))
             xs.mark_sharding(attn_output, data_model_mesh, (0, 1, 2))
+            if self.spmd_iota_mesh:
+                mesh = xs.Mesh(device_ids, (data, 1, model))
+            else:
+                mesh = xs.HybridMesh(ici_mesh_shape=(data, 1, model))
+            xs.mark_sharding(attn_output, mesh, (0, 1, 2))
             if self.spmd_debug:
                 print(torch_xla._XLAC._get_xla_sharding_spec(attn_output))
 
@@ -584,6 +589,7 @@ class LlamaModel(LlamaPreTrainedModel):
         # For PyTorch/XLA's SPMD 2D sharding
         self.spmd_2d_sharding = config.spmd_2d_sharding
         self.spmd_debug = config.spmd_debug
+        self.spmd_iota_mesh = config.spmd_iota_mesh
 
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
@@ -700,8 +706,11 @@ class LlamaModel(LlamaPreTrainedModel):
             model = self.spmd_2d_sharding
             data = num_devices // model
             assert model * data == num_devices
-            data_model_mesh = xs.HybridMesh(ici_mesh_shape=(data, 1, model))
-            xs.mark_sharding(hidden_states, data_model_mesh, (0, 1, 2))
+            if self.spmd_iota_mesh:
+                mesh = xs.Mesh(device_ids, (data, 1, model))
+            else:
+                mesh = xs.HybridMesh(ici_mesh_shape=(data, 1, model))
+            xs.mark_sharding(hidden_states, mesh, (0, 1, 2))
             if self.spmd_debug:
                 print(torch_xla._XLAC._get_xla_sharding_spec(hidden_states))
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1456,15 +1456,25 @@ class Trainer:
             num_devices = xr.global_runtime_device_count()
             device_ids = np.arange(num_devices)
 
+            def get_mesh(ici_mesh_shape, dcn_mesh_shape=None):
+              if self.args.spmd_iota_mesh:
+                if dcn_mesh_shape is not None:
+                  assert len(ici_mesh_shape) == len(dcn_mesh_shape)
+                  for i in range(len(dcn_mesh_shape)):
+                    ici_mesh_shape[i] *= dcn_mesh_shape[i]
+                return xs.Mesh(device_ids, ici_mesh_shape)
+              else:
+                return xs.HybridMesh(ici_mesh_shape=ici_mesh_shape, dcn_mesh_shape=dcn_mesh_shape)
+
             sharding_spec = None
             if self.args.spmd_batch_sharding:
-                mesh = xs.Mesh(device_ids, (num_devices, 1))
+                mesh = get_mesh((num_devices, 1))
                 sharding_spec = xs.ShardingSpec(mesh, (0, 1))
             elif self.args.spmd_tensor_sharding > 0 or self.args.spmd_2d_sharding > 0:
                 assert self.args.spmd_tensor_sharding == 0 or self.args.spmd_2d_sharding == 0
                 tensor = self.args.spmd_tensor_sharding + self.args.spmd_2d_sharding
                 fsdp = num_devices // tensor
-                mesh = xs.HybridMesh(ici_mesh_shape=(fsdp, tensor))
+                mesh = get_mesh((fsdp, tensor))
                 partition_spec = (0, None)
                 sharding_spec = xs.ShardingSpec(mesh, partition_spec)
 


### PR DESCRIPTION
Add a flag to use iota device assignment instead of HybridMesh. Additionally, use partition_spec to reorder mesh instead of using two different meshes.