### PR TITLE
[2D] Let's shard every matmul

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -544,6 +544,11 @@ def main():
             mesh_shape = (num_devices,) + (1,) * (len(param.shape) - 1)
             print('> [FSDP] Sharding tensor', name, param.shape)
             mesh = xs.HybridMesh(ici_mesh_shape=tuple(mesh_shape))
+            # We don't care about layernorm's weights, and
+            # LLaMA doesn't use biases.
+            if len(param.shape) == 1:
+                continue
+            assert len(param.shape) == 2
             xs.mark_sharding(param, mesh, range(len(param.shape)))
         elif model_args.spmd_tensor_sharding > 0:
             # Shard all parameters along two axis except 1D tensors

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -477,7 +477,7 @@ def main():
     config.spmd_model_axis = model_args.spmd_2d_sharding + model_args.spmd_tensor_sharding
     if config.spmd_model_axis == 0:
         config.spmd_model_axis = 1
-    else
+    else:
         assert model_args.spmd_2d_sharding == 0 or model_args.spmd_tensor_sharding == 0
     config.spmd_debug = model_args.spmd_debug
     config.spmd_iota_mesh = model_args.spmd_iota_mesh

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -515,7 +515,7 @@ def main():
     num_devices = xr.global_runtime_device_count()
     device_ids = torch.arange(num_devices)
     print('Using dtype', model_args.torch_dtype)
-    model = model.to(xm.xla_device(), dtype=getattr(torch, model_args.torch_dtype))
+    model = model.to(dtype=getattr(torch, model_args.torch_dtype))
 
     def get_mesh(ici_mesh_shape, dcn_mesh_shape=None):
       if model_args.spmd_iota_mesh:

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -475,6 +475,7 @@ def main():
 
     # Pass the 2d sharding config to the actual model.
     config.spmd_2d_sharding = model_args.spmd_2d_sharding
+    config.spmd_tensor_sharding = model_args.spmd_tensor_sharding
     config.spmd_debug = model_args.spmd_debug
     config.spmd_iota_mesh = model_args.spmd_iota_mesh
     with init_empty_weights():
@@ -527,72 +528,71 @@ def main():
     # Convert the model from meta to XLA tensors one layer at a time to avoid
     # host-side OOM
     for name, param in model.state_dict().items():
-      # Create an tensor based on the meta tensor
-      param = torch.empty_like(param, device=xm.xla_device())
-      torch.nn.init.uniform_(param, a=-0.05, b=0.05)
-      # TODO(jonbolin): Can't load_state_dict when the module consists of meta tensors
-      path = re.sub(r'.(\d+)', r'[\1]', name)
-      assign = f'model.{path} = torch.nn.Parameter(param)'
-      print(f'running "{assign}"')
-      exec(assign)
+        # Create an tensor based on the meta tensor
+        param = torch.empty_like(param, device=xm.xla_device())
+        torch.nn.init.uniform_(param, a=-0.05, b=0.05)
+        # TODO(jonbolin): Can't load_state_dict when the module consists of meta tensors
+        path = re.sub(r'.(\d+)', r'[\1]', name)
+        assign = f'model.{path} = torch.nn.Parameter(param)'
+        print(f'running "{assign}"')
+        exec(assign)
 
-      # Mark sharding based on the model_args
-      if model_args.spmd_fsdp_sharding:
-          import numpy as np
-          max_dim = np.argmax(param.shape)
-          mesh_shape = [1] * len(param.shape)
-          mesh_shape[max_dim] = num_devices
-          print('> [FSDP] Sharding tensor', name, param.shape, mesh_shape)
-          mesh = get_mesh(tuple(mesh_shape))
-          xs.mark_sharding(param, mesh, range(len(param.shape)))
-      elif model_args.spmd_tensor_sharding > 0:
-          # Shard all parameters along two axis except 1D tensors
-          print('> [TP] Sharding tensor', name, param.shape)
-          tensor = model_args.spmd_tensor_sharding
-          fsdp = num_devices // tensor
-          assert fsdp * tensor == num_devices
-          mesh = get_mesh((fsdp, tensor))
-          if len(param.shape) == 1:
-              xs.mark_sharding(param, mesh, (1,))
-          else:
-              assert len(param.shape) == 2
-              xs.mark_sharding(param, mesh, range(len(param.shape)))
-      elif model_args.spmd_2d_sharding > 0:
-          # Apply 2D sharding:
-          # embedding (model, data)
-          # attn QKV (data, model)
-          # attn O (model, data)
-          # mlp gate, up (model, data)
-          # mlp down (data, model)
-          print('> [2D] Sharding tensor', name, param.shape)
-          mod = model_args.spmd_2d_sharding
-          data = num_devices // mod
-          assert mod * data == num_devices
-          mesh = get_mesh((data, mod))
-          data_model = (0, 1)
-          model_data = (1, 0)
+        # Mark sharding based on the model_args
+        if model_args.spmd_fsdp_sharding:
+            import numpy as np
+            max_dim = np.argmax(param.shape)
+            mesh_shape = [1] * len(param.shape)
+            mesh_shape[max_dim] = num_devices
+            print('> [FSDP] Sharding tensor', name, param.shape, mesh_shape)
+            mesh = xs.HybridMesh(ici_mesh_shape=tuple(mesh_shape))
+            xs.mark_sharding(param, mesh, range(len(param.shape)))
+        elif model_args.spmd_tensor_sharding > 0:
+            # Shard all parameters along two axis except 1D tensors
+            print('> [TP] Sharding tensor', name, param.shape)
+            tensor = model_args.spmd_tensor_sharding
+            fsdp = num_devices // tensor
+            assert fsdp * tensor == num_devices
+            mesh = xs.Mesh(device_ids, (fsdp, tensor))
+            # We don't care about layernorm's weights, and
+            # LLaMA doesn't use biases.
+            if len(param.shape) == 1:
+                continue
+            assert len(param.shape) == 2
+            xs.mark_sharding(param, mesh, range(len(param.shape)))
+        elif model_args.spmd_2d_sharding > 0:
+            # Apply 2D sharding:
+            # embedding (model, data)
+            # attn QKV (data, model)
+            # attn O (model, data)
+            # mlp gate, up (model, data)
+            # mlp down (data, model)
+            print('> [2D] Sharding tensor', name, param.shape)
+            mod = model_args.spmd_2d_sharding
+            data = num_devices // mod
+            assert mod * data == num_devices
+            data_model_mesh = xs.HybridMesh(ici_mesh_shape=(data, mod))
+            model_data_mesh = xs.HybridMesh(ici_mesh_shape=(mod, data))
 
-          # We don't care about layernorm's weights, and
-          # LLaMA doesn't use biases.
-          if len(param.shape) == 1:
-              continue
+            # We don't care about layernorm's weights, and
+            # LLaMA doesn't use biases.
+            if len(param.shape) == 1:
+                continue
 
-          assert len(param.shape) == 2
-          if 'embed_tokens' in name:
-              xs.mark_sharding(param, mesh, model_data)
-          elif 'q_proj' in name or 'k_proj' in name or 'v_proj' in name:
-              xs.mark_sharding(param, mesh, data_model)
-          elif 'o_proj' in name:
-              xs.mark_sharding(param, mesh, model_data)
-          elif 'gate_proj' in name or 'up_proj' in name:
-              xs.mark_sharding(param, mesh, model_data)
-          elif 'down_proj' in name:
-              xs.mark_sharding(param, mesh, data_model)
-          elif 'lm_head' in name:  # Not sure what this is but has the same shape as embed_tokens
-              xs.mark_sharding(param, mesh, model_data)
+            if 'embed_tokens' in name:
+                xs.mark_sharding(param, model_data_mesh, range(len(param.shape)))
+            elif 'q_proj' in name or 'k_proj' in name or 'v_proj' in name:
+                xs.mark_sharding(param, data_model_mesh, range(len(param.shape)))
+            elif 'o_proj' in name:
+                xs.mark_sharding(param, model_data_mesh, range(len(param.shape)))
+            elif 'gate_proj' in name or 'up_proj' in name:
+                xs.mark_sharding(param, model_data_mesh, range(len(param.shape)))
+            elif 'down_proj' in name:
+                xs.mark_sharding(param, data_model_mesh, range(len(param.shape)))
+            elif 'lm_head' in name:  # Not sure what this is but has the same shape as embed_tokens
+                xs.mark_sharding(param, model_data_mesh, range(len(param.shape)))
 
-          import torch_xla
-          print(torch_xla._XLAC._get_xla_sharding_spec(param))
+            import torch_xla
+            print(torch_xla._XLAC._get_xla_sharding_spec(param))
 
     # Move anything remaining to the xla device
     model = model.to(xm.xla_device())

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -513,7 +513,7 @@ def main():
     num_devices = xr.global_runtime_device_count()
     device_ids = torch.arange(num_devices)
     print('Using dtype', model_args.torch_dtype)
-    model = model.to(dtype=getattr(torch, model_args.torch_dtype))
+    model = model.to(xm.xla_device(), dtype=getattr(torch, model_args.torch_dtype))
 
     def get_mesh(ici_mesh_shape, dcn_mesh_shape=None):
       if model_args.spmd_iota_mesh:

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -474,9 +474,11 @@ def main():
         )
 
     # Pass the 2d sharding config to the actual model.
-    config.spmd_2d_sharding = model_args.spmd_2d_sharding
-    config.spmd_tensor_sharding = model_args.spmd_tensor_sharding
-    config.spmd_fsdp_sharding = model_args.spmd_fsdp_sharding
+    config.spmd_model_axis = model_args.spmd_2d_sharding + model_args.spmd_tensor_sharding
+    if config.spmd_model_axis == 0:
+        config.spmd_model_axis = 1
+    else
+        assert model_args.spmd_2d_sharding == 0 or model_args.spmd_tensor_sharding == 0
     config.spmd_debug = model_args.spmd_debug
     config.spmd_iota_mesh = model_args.spmd_iota_mesh
     with init_empty_weights():

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -371,8 +371,8 @@ class LlamaAttention(nn.Module):
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
-        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+        # cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        # query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:
             # reuse k, v, self_attention

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -209,6 +209,7 @@ def get_mesh(spmd_iota_mesh, ici_mesh_shape, dcn_mesh_shape=None):
             assert len(ici_mesh_shape) == len(dcn_mesh_shape)
             for i in range(len(dcn_mesh_shape)):
                 ici_mesh_shape[i] *= dcn_mesh_shape[i]
+        num_devices = xr.global_runtime_device_count()
         device_ids = torch.arange(num_devices)
         return xs.Mesh(device_ids, ici_mesh_shape)
     else:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -364,7 +364,7 @@ class LlamaAttention(nn.Module):
         # Apply 2D sharding:
         # query_states (batch, length, hidden)
         # key_states (batch, length, hidden / attention_heads * key_value_heads)
-        # key_states (batch, length, hidden / attention_heads * key_value_heads)
+        # value_states (batch, length, hidden / attention_heads * key_value_heads)
         # mesh (data, None, model)
         if self.spmd_iota_mesh:
             data_model_mesh = xs.Mesh(device_ids, (self.spmd_data_axis, 1, self.spmd_model_axis))
@@ -452,10 +452,10 @@ class LlamaAttention(nn.Module):
             attn_weights = None
 
         # Apply 2D sharding:
-        # activations (batch, length, hidden)
+        # attn_output (batch, length, hidden)
         # mesh (data, None, model)
         if self.spmd_debug:
-            print('> Sharding activations', attn_output.shape)
+            print('> Sharding attn_output', attn_output.shape)
         xs.mark_sharding(attn_output, data_model_mesh, range(len(attn_output.shape)))
         if self.spmd_debug:
             print(torch_xla._XLAC._get_xla_sharding_spec(attn_output))

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -268,7 +268,7 @@ class LlamaMLP(nn.Module):
             if self.spmd_debug:
                 print(torch_xla._XLAC._get_xla_sharding_spec(gate_proj))
 
-            down_proj = self.down_proj(self.act_fn(gate_proj) * up_proj)
+            down_proj = self.down_proj(gate_proj * up_proj)
             # down_proj (batch, length, hidden)
             # mesh (data, None, model)
             if self.spmd_debug:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -241,7 +241,8 @@ class LlamaAttention(nn.Module):
         super().__init__()
         self.config = config
         # For PyTorch/XLA's SPMD 2D sharding
-        self.spmd_2d_sharding = config.spmd_2d_sharding
+        assert config.spmd_2d_sharding & config.spmd_tensor_sharding == 0
+        self.spmd_2d_sharding = config.spmd_2d_sharding + config.spmd_tensor_sharding
         self.spmd_debug = config.spmd_debug
         self.spmd_iota_mesh = config.spmd_iota_mesh
         self.hidden_size = config.hidden_size
@@ -587,7 +588,8 @@ class LlamaModel(LlamaPreTrainedModel):
     def __init__(self, config: LlamaConfig):
         super().__init__(config)
         # For PyTorch/XLA's SPMD 2D sharding
-        self.spmd_2d_sharding = config.spmd_2d_sharding
+        assert config.spmd_2d_sharding & config.spmd_tensor_sharding == 0
+        self.spmd_2d_sharding = config.spmd_2d_sharding + config.spmd_tensor_sharding
         self.spmd_debug = config.spmd_debug
         self.spmd_iota_mesh = config.spmd_iota_mesh
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1814,6 +1814,9 @@ class Trainer:
             profile_duration = int(os.environ.get('PROFILE_DURATION_MS', 20000))
             profile_logdir = os.environ.get('PROFILE_LOGDIR', None)
             for step, inputs in enumerate(epoch_iterator):
+                if step > 0:
+                    break
+
                 if step == 0 and epoch == 0:
                     print('input sharding', {k: (v.shape, torch_xla._XLAC._get_xla_sharding_spec(v)) for k, v in inputs.items()})
                 total_batched_samples += 1

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1814,9 +1814,6 @@ class Trainer:
             profile_duration = int(os.environ.get('PROFILE_DURATION_MS', 20000))
             profile_logdir = os.environ.get('PROFILE_LOGDIR', None)
             for step, inputs in enumerate(epoch_iterator):
-                if step > 0:
-                    break
-
                 if step == 0 and epoch == 0:
                     print('input sharding', {k: (v.shape, torch_xla._XLAC._get_xla_sharding_spec(v)) for k, v in inputs.items()})
                 total_batched_samples += 1


### PR DESCRIPTION
Summary:
This pull requst tries to shard every matmul in LLaMA, below is the sharding strategy:
1. up_proj (batch, length, intermediate): mesh (data, None, model)
2. gate_proj (batch, length, intermediate): mesh (data, None, model)
3. down_proj (batch, length, hidden): mesh (data, None, model)
4. query_states (batch, length, hidden): mesh (data, None, model)
5. key_states (batch, length, hidden / attention_heads * key_value_heads): mesh (data, None, model)
6. value_states (batch, length, hidden / attention_heads * key_value_heads): mesh (data, None, model)
7. attn_weights (batch, num_attention_heads, length, length): mesh (data, model, none, none)
8. attn_output (batch, length, hidden): mesh (data, None, model)
9. hidden_states (batch, length, hidden): mesh (data, None, model)

Test Plan:
Tested on v4-8