### PR TITLE
Revert back to meta device for deferred init

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -841,7 +841,8 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["worker_init_fn"] = seed_worker
 
-        # TODO(jonbolin): Disabling Accelerate on the dataloader (`Unknown device SPMD:0`)
+        # TODO(jonbolin): Disabling Accelerate on the dataloader. Accelerate does not
+        # currently support SPMD-mode
         return DataLoader(train_dataset, **dataloader_params)
 
     def _get_eval_sampler(self, eval_dataset: Dataset) -> Optional[torch.utils.data.Sampler]:


### PR DESCRIPTION
We found that the shard-in-init approach increased memory pressure for FSDP sharding. This change reverts back to the meta tensor approach.

This also includes some small cleanup.