### PR TITLE
Enforce sharding flags are mutually exclusive

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -469,6 +469,10 @@ def main():
     import torch_xla.core.xla_model as xm
     import torch_xla.experimental.xla_sharding as xs
 
+    # Ensure only one sharding scheme is provided
+    assert not model_args.spmd_fsdp_sharding or model_args.spmd_2d_sharding == 0, \
+        "Only one of --spmd_2d_sharding and --spmd_fsdp_sharding may be specified."
+
     # Pass the sharding parameters to the model config
     config.spmd_debug = model_args.spmd_debug
     config.spmd_fsdp_sharding = model_args.spmd_fsdp_sharding


### PR DESCRIPTION
We need to enforce that both fsdp and 2D sharding are not specified for the same run.