### PR TITLE
Add training data augment flag

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -267,9 +267,9 @@ class DataTrainingArguments:
     keep_linebreaks: bool = field(
         default=True, metadata={"help": "Whether to keep line breaks when using TXT files or not."}
     )
-    augment_factor: Optional[int] = field(
+    train_data_augment_factor: Optional[int] = field(
         default=None,
-        metadata={"help": "Augmentation factor to augment dataset by duplication."},
+        metadata={"help": "Augmentation factor to augment training dataset by duplication."},
     )
 
     def __post_init__(self):
@@ -369,8 +369,8 @@ def main():
             use_auth_token=True if model_args.use_auth_token else None,
             streaming=data_args.streaming,
         )
-        if data_args.augment_factor is not None:
-            augment_factor = data_args.augment_factor
+        if data_args.train_data_augment_factor is not None:
+            augment_factor = data_args.train_data_augment_factor
             augment_list = []
             for _ in range(augment_factor):
                 augment_list.append(raw_datasets['train'])


### PR DESCRIPTION
Add an arg to augment training data by duplicating the original dataset. The purpose is to capture more graphs during the profiling, so the warm latency can be captured.

Test on v5-8 with 2B LLaMA config
```
python examples/pytorch/language-modeling/run_clm.py \
  --tokenizer_name hf-internal-testing/llama-tokenizer \
  --dataset_name wikitext \
  --dataset_config_name wikitext-2-raw-v1 \
  --per_device_train_batch_size 256 \
  --num_train_epochs 1 \
  --do_train \
  --output_dir /tmp/output \
  --overwrite_output_dir \
  --config_name /tmp/hf_llama/2B.json \
  --save_strategy no \
  --logging_strategy no \
  --remove_unused_columns no \
  --optim adafactor \
  --torch_dtype bfloat16 \
  --dataloader_drop_last yes \
  --block_size 1024 \
  --spmd_2d_sharding 1 \
  --spmd_grad_chkpt \
  --train_data_augment_factor 2
```
Log with training data augmented
```
[INFO|trainer.py:1687] 2023-10-06 23:21:27,042 >> ***** Running training *****
[INFO|trainer.py:1688] 2023-10-06 23:21:27,043 >>   Num examples = 5,376
...
2023-10-06 23:23:05.712496: W external/tsl/tsl/profiler/lib/profiler_session.cc:110] Profiling is late by 1254990 nanoseconds and will start immediately.
100%|██████████████████████████████████| 21/21 [02:42<00:00,  3.62s/it]
```
Log without data augmented
```
INFO|trainer.py:1687] 2023-10-06 22:11:00,509 >> ***** Running training *****
[INFO|trainer.py:1688] 2023-10-06 22:11:00,509 >>   Num examples = 2,560
[INFO|trainer.py:1689] 2023-10-06 22:11:00,509 >>   Num Epochs = 1
...
100%|██████████████████████████████████| 10/10 [01:52<00:00,  5.00s/it]
```