### PR TITLE
Use CheckpointManager for checkpointing

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -778,7 +778,9 @@ def main():
         elif last_checkpoint is not None:
             checkpoint = last_checkpoint
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
-        trainer.save_model()  # Saves the tokenizer too for easy upload
+        # TODO(jonbolin): For our benchmarks, we don't need to persist the final training result.
+        # This should be re-enabled if the final result is needed in a non-checkpoint form.
+        #trainer.save_model()  # Saves the tokenizer too for easy upload
 
         metrics = train_result.metrics
 

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -592,3 +592,15 @@ class EarlyStoppingCallback(TrainerCallback):
         self.check_metric_value(args, state, control, metric_value)
         if self.early_stopping_patience_counter >= self.early_stopping_patience:
             control.should_training_stop = True
+
+
+class CheckpointManagerCallback(TrainerCallback):
+    """
+    A TrainerCallback which uses the CheckpointManager to select additional steps for checkpointing,
+    e.g. when a preemption is detected.
+    """
+    def __init__(self, chkpt_manager: 'CheckpointManager'):
+        self.chkpt_manager = chkpt_manager
+
+    def on_step_end(self, args, state, control, **kwargs):
+        control.should_save = self.chkpt_manager.should_save(state.global_step) or control.should_save

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -625,17 +625,18 @@ class TrainingArguments:
             This will iterate over the entire training dataloader once beforehand,
 
             and will slow down the entire process.
-        use_checkpoint_manager (`bool`, *optional*):
-            Whether or not to use the CheckpointManager to run distributed checkpoints.
+        checkpoint_manager_path (`str`, *optional*):
+            Path for CheckpointManager to target when saving checkpoints. Specifying this field will enable
+            CheckpointManager.
     """
 
     framework = "pt"
     output_dir: str = field(
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."},
     )
-    use_checkpoint_manager: Optional[bool] = field(
-        default=False,
-        metadata={"help": "If set to `True`, uses the CheckpointManager to save state."},
+    checkpoint_manager_path: Optional[str] = field(
+        default=None,
+        metadata={"help": "Specify the path for CheckpointManager will checkpoint to. This flag controls whether or not CheckpointManager will be used - if unspecified, CheckpointManager will not be used."},
     )
     overwrite_output_dir: bool = field(
         default=False,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -625,11 +625,17 @@ class TrainingArguments:
             This will iterate over the entire training dataloader once beforehand,
 
             and will slow down the entire process.
+        use_checkpoint_manager (`bool`, *optional*):
+            Whether or not to use the CheckpointManager to run distributed checkpoints.
     """
 
     framework = "pt"
     output_dir: str = field(
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."},
+    )
+    use_checkpoint_manager: Optional[bool] = field(
+        default=False,
+        metadata={"help": "If set to `True`, uses the CheckpointManager to save state."},
     )
     overwrite_output_dir: bool = field(
         default=False,


### PR DESCRIPTION
[CheckpointManager](https://github.com/pytorch/xla/blob/46643801a5da36106c346d0434387c29d3a7818d/torch_xla/experimental/distributed_checkpoint/manager.py#L39) provides an interface for distributed checkpointing with SPMD.

This change integrates CheckpointManager into the standard HF checkpoint control path. This is an early integration, and the final form of the integration is subject to change significantly. It will provide a convenient way for end-to-end testing of checkpointing and convergence.

Tested by checkpointing locally with ~`--use_checkpoint_manager --save_strategy epoch`~ `--checkpoint_manager_path gs://pytorch-spmd-benchmark-profile/devbox/1700201148` with a 2B Llama config for 1 epoch, achieving a loss of `10.2381`. Then, re-ran for 2 epochs, and observed the checkpoint resumed from the end of the first epoch, resulting in a loss of `5.0476` (normalizes to approximately `10.0952`, which shows the loss resumed decreasing):

```
...
[INFO|trainer.py:1754] 2023-11-09 04:58:09,244 >>   Continuing training from checkpoint, will skip to saved global_step
[INFO|trainer.py:1755] 2023-11-09 04:58:09,244 >>   Continuing training from epoch 1
[INFO|trainer.py:1756] 2023-11-09 04:58:09,244 >>   Continuing training from global step 21
[INFO|trainer.py:1758] 2023-11-09 04:58:09,244 >>   Will skip the first 1 epochs then the first 0 batches in the first epoch.
...
```

This change depends on https://github.com/pytorch/xla/pull/5770 for a fix in async checkpointing.