### PR TITLE
Use trace_detached for programmatic profile

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1829,8 +1829,7 @@ class Trainer:
 
                 if step == profile_step and epoch == profile_epoch:
                     import tempfile
-                    trace = lambda: xp.trace('127.0.0.1:9012', profile_logdir or tempfile.mkdtemp(), profile_duration or 20000)
-                    Thread(target=trace).start()
+                    xp.trace_detached('127.0.0.1:9012', profile_logdir or tempfile.mkdtemp(), profile_duration or 20000)
 
                 with self.accelerator.accumulate(model):
                     tr_loss_step = self.training_step(model, inputs)


### PR DESCRIPTION
I recently added a new API to simplify programmatic captures in https://github.com/pytorch/xla/pull/5969. This hides the background thread creation from the user.