### PR TITLE
Use apply_backward_optimization_barrier

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -622,6 +622,10 @@ def main():
 
         print(f'{name} {torch_xla._XLAC._get_xla_sharding_spec(param)}')
 
+    for i, block in enumerate(model.model.layers):
+        # LLaMA-specific
+        xs.apply_backward_optimization_barrier(model.model.layers[i])
+
     if model_args.spmd_grad_chkpt:
         print("Applying gradient checkpointing")
         from torch_xla.distributed.fsdp import checkpoint_module


### PR DESCRIPTION
Summary:
This PR uses the latest apply_backward_optimization_barrier to prevent gigantic buffers being allocated to synchronize gradients.

Test Plan:
Manually on a v4-8.