### PR TITLE
Support XLA autocast and enable persistent caching

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -63,8 +63,6 @@ import torch_xla.runtime as xr
 
 # Enable SPMD mode execution
 xr.use_spmd()
-# Enable persistent caching
-xr.initialize_cache('/tmp/cache', readonly=xr.process_index() != 0)
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -63,6 +63,8 @@ import torch_xla.runtime as xr
 
 # Enable SPMD mode execution
 xr.use_spmd()
+# Enable persistent caching
+xr.initialize_cache('/tmp/cache', readonly=xr.process_index() != 0)
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -172,6 +172,7 @@ if is_datasets_available():
 if is_torch_tpu_available(check_device=False):
     import torch_xla
     import torch_xla.core.xla_model as xm
+    import torch_xla.runtime as xr
     import torch_xla.debug.metrics as met
 
 
@@ -355,6 +356,10 @@ class Trainer:
 
         # force device and distributed setup init explicitly
         args._setup_devices
+
+        if args.xla_cache_path:
+            readonly = args.xla_cache_single_writer and xr.process_index() != 0
+            xr.initialize_cache(args.xla_cache_path, readonly)
 
         if model is None:
             if model_init is not None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -636,6 +636,8 @@ class TrainingArguments:
     )
     xla_execution_time_step: int = field(default=None, metadata={"help": "Global step to measure the on-device step execution time when using torch_xla."})
     xla_autocast: bool = field(default=False, metadata={"help": "Use autocast for training with torch_xla"})
+    xla_cache_path: Optional[str] = field(default=None, metadata={"help": "Path for the persistent compilation caching with torch_xla"})
+    xla_cache_single_writer: bool = field(default=False, metadata={"help": "Whether or not only process 0 can write to the cache in torch_xla"})
     checkpoint_manager_path: Optional[str] = field(
         default=None,
         metadata={"help": "Specify the path for CheckpointManager will checkpoint to. This flag controls whether or not CheckpointManager will be used - if unspecified, CheckpointManager will not be used."},

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -635,6 +635,7 @@ class TrainingArguments:
         metadata={"help": "The output directory where the model predictions and checkpoints will be written."},
     )
     xla_execution_time_step: int = field(default=None, metadata={"help": "Global step to measure the on-device step execution time when using torch_xla."})
+    xla_autocast: bool = field(default=False, metadata={"help": "Use autocast for training with torch_xla"})
     checkpoint_manager_path: Optional[str] = field(
         default=None,
         metadata={"help": "Specify the path for CheckpointManager will checkpoint to. This flag controls whether or not CheckpointManager will be used - if unspecified, CheckpointManager will not be used."},


### PR DESCRIPTION
- Enable XLA autocasting in the HF trainer via `--xla_autocast`
- Enable persistent caching with `--xla_cache_path` and `--xla_cache_single_writer`

`--xla_cache_single_writer` will only allow process 0 to write to the cache when specified.