### PR TITLE
Remove block size limitation

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -681,12 +681,13 @@ def main():
             )
             block_size = min(1024, config.max_position_embeddings)
     else:
-        if data_args.block_size > tokenizer.model_max_length:
-            logger.warning(
-                f"The block_size passed ({data_args.block_size}) is larger than the maximum length for the model "
-                f"({tokenizer.model_max_length}). Using block_size={tokenizer.model_max_length}."
-            )
-        block_size = min(data_args.block_size, tokenizer.model_max_length)
+        #if data_args.block_size > tokenizer.model_max_length:
+        #    logger.warning(
+        #        f"The block_size passed ({data_args.block_size}) is larger than the maximum length for the model "
+        #        f"({tokenizer.model_max_length}). Using block_size={tokenizer.model_max_length}."
+        #    )
+        #block_size = min(data_args.block_size, tokenizer.model_max_length)
+        block_size = data_args.block_size
 
     # Main data processing function that will concatenate all texts from our dataset and generate chunks of block_size.
     def group_texts(examples):


### PR DESCRIPTION
To train with sequence lengths longer than 2048, we need to bypass the limitation enforced in run_clm, which is likely a safeguard for finetuning.

Long-term, it would also make sense to retrain a tokenizer with a larger sequence length, but this will unblock early tests with the default tokenizer. 