### PR TITLE
Fix the kv_seq_len in the assert statements after the previous merge.

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -429,6 +429,7 @@ class LlamaAttention(nn.Module):
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
+        kv_seq_len = key_states.shape[-2]
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
 
@@ -436,7 +437,7 @@ class LlamaAttention(nn.Module):
         # key_states   Batch Num_head Kv_seq Head_dim
         #attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
         assert query_states.shape == torch.Size((bsz, self.num_heads, q_len, self.head_dim)), f'incorrect query_states shape: {query_states.shape}'
-        assert key_states.shape == torch.Size((bsz, self.num_heads, q_len, self.head_dim)), f'incorrect key_states_states shape: {key_states.shape}'
+        assert key_states.shape == torch.Size((bsz, self.num_heads, kv_seq_len, self.head_dim)), f'incorrect key_states_states shape: {key_states.shape}'
         attn_weights = torch.einsum('bnsh,bnkh->bnsk', query_states, key_states) / math.sqrt(self.head_dim)
         # Apply 2D sharding:
         # attn_weights (batch, num_attention_heads, length, length)
@@ -458,8 +459,8 @@ class LlamaAttention(nn.Module):
         # attn_weights Batch Num_head Seq Kv_seq
         # value_states Batch Num_head Seq Head_dim
         # attn_output = torch.matmul(attn_weights, value_states)
-        assert attn_weights.shape == torch.Size((bsz, self.num_heads, q_len, q_len)), f'incorrect atten_weight shape: {attn_weights.shape}'
-        assert value_states.shape == torch.Size((bsz, self.num_heads, q_len, self.head_dim)), f'incorrect value_states shape: {value_states.shape}'
+        assert attn_weights.shape == torch.Size((bsz, self.num_heads, q_len, kv_seq_len)), f'incorrect atten_weight shape: {attn_weights.shape}'
+        assert value_states.shape == torch.Size((bsz, self.num_heads, kv_seq_len, self.head_dim)), f'incorrect value_states shape: {value_states.shape}'
         attn_output = torch.einsum('bnsk,bnkh->bnsh', attn_weights, value_states)
 
         if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In the previous merge https://github.com/pytorch-tpu/transformers/pull/62, we used `q_len` to replace the `kv_seq_len`. It fails when I ran it on llama2 on GPU multi-host case. This PR uses the correct `kv_seq_len` in the assert statements.

From reading the function `repeat_kv` https://github.com/pytorch-tpu/transformers/blob/3e8a48dd0e5d08a0be8d4662006539d201d7e95d/src/transformers/models/llama/modeling_llama.py#L293, I think we should replace kv_seq_len with key_states.shape[-2] because this is how `repeat_kv` got the seq_len at https://github.com/pytorch-tpu/transformers/blob/3e8a48dd0e5d08a0be8d4662006539d201d7e95d/src/transformers/models/llama/modeling_llama.py#L293.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
