### PR TITLE
Bring up Llama 3.1 405B on two pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+ir_dumps/
+xla_dumps/
+scan-offload-ptxla.txt.0
+
 # Initially taken from Github's Python gitignore file
 
 # Byte-compiled / optimized / DLL files

--- a/examples/pytorch/language-modeling/_hybrid_mesh.py
+++ b/examples/pytorch/language-modeling/_hybrid_mesh.py
@@ -1,0 +1,72 @@
+import dataclasses
+import collections
+import numpy as np
+from typing import Sequence, Any
+from jax.experimental import mesh_utils
+import jax
+
+def create_custom_64x4_device_mesh(
+    mesh_shape: Sequence[int],
+    dcn_mesh_shape: Sequence[int],
+    devices: Sequence[Any],
+    process_is_granule: bool = False,
+    should_sort_granules_by_key: bool = True,
+) -> np.ndarray:
+  """Custom device mesh for 64x4 ici parallelism"""
+  assert len(devices) % 256 == 0, f"This custom mesh is not valid for {len(devices)} devices"
+  attr = "process_index" if process_is_granule else "slice_index"
+  if not hasattr(devices[0], attr):
+    raise ValueError(f"Device {devices[0]} does not have attribute {attr}. See" " `process_is_granule` option.")
+  granule_dict = collections.defaultdict(list)
+  for dev in devices:
+    granule_dict[getattr(dev, attr)].append(dev)
+  granules = (
+      [granule_dict[key] for key in sorted(granule_dict.keys())] if should_sort_granules_by_key else granule_dict.values()
+  )
+  if np.prod(dcn_mesh_shape) != len(granules):
+    raise ValueError(f"Number of slices {len(granules)} must equal the product of " f"dcn_mesh_shape {dcn_mesh_shape}")
+  per_granule_meshes = [
+      mesh_utils.create_device_mesh(
+          [16, 16],
+          granule,
+          allow_split_physical_axes=False,
+      )
+      for granule in granules
+  ]
+
+  def reshape_mesh_to_rings(a):
+    b = []
+    for i in range(8):
+      b.append([])
+      for j in range(8):
+        a_i = i * 2
+        a_j = j * 2
+        # forms a ring of size 4
+        b[i].append([a[a_i, a_j], a[a_i, a_j + 1], a[a_i + 1, a_j + 1], a[a_i + 1, a_j]])
+    b = np.array(b)
+    b = np.reshape(b, (64, 4))
+    return b
+
+  per_granule_meshes = [np.reshape(reshape_mesh_to_rings(x), mesh_shape) for x in per_granule_meshes]
+  # TODO(jekbradbury): handle non-uniform DCN topologies
+  granule_mesh = np.arange(len(granules)).reshape(dcn_mesh_shape)
+  blocks = np.vectorize(lambda i: per_granule_meshes[i], otypes=[object])(granule_mesh)
+  device_mesh = np.block(blocks.tolist())
+  return device_mesh
+
+
+@dataclasses.dataclass
+class Device:
+  process_index: int
+  slice_index: int
+  uid: int
+  device_kind: str = ''
+  platform: str = 'cpu'
+
+
+def get_hybrid_mesh(ici_mesh_shape: Sequence[int], dcn_mesh_shape: Sequence[int], num_devices: int, num_slices: int) -> np.ndarray:
+  num_devices_per_granule = num_devices // num_slices
+  devices = [Device(i // num_devices_per_granule, i // num_devices_per_granule, i) for i in range(num_devices)]
+  devices = create_custom_64x4_device_mesh(ici_mesh_shape, dcn_mesh_shape, devices).reshape(-1).tolist()
+  devices = np.array(jax.tree_map(lambda d: d.uid, devices))
+  return devices

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -628,7 +628,8 @@ def main():
     model.model.scan_bw_output_sharder = bw_output_sharder
 
     # Materialize all weights after 2d sharding
-    torch_xla.sync()
+    torch_xla.sync(wait=True)
+    xm.wait_device_ops()
 
     # Preprocessing the datasets.
     # First we tokenize all the texts.

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -495,6 +495,7 @@ def main():
             tensor_axis = model_args.spmd_2d_sharding
             fsdp_axis = num_devices // tensor_axis
             mesh_shape = (fsdp_axis, tensor_axis)
+            logger.info(f"Single-slice sharding: mesh={mesh_shape}")
             spmd_mesh = xs.Mesh(range(num_devices), mesh_shape, ('fsdp', 'tensor'))
         else:
             # Multi-slice 2D sharding
@@ -503,6 +504,7 @@ def main():
             fsdp_axis = num_devices // tensor_axis // dcn_axis
             ici_mesh_shape = (fsdp_axis, tensor_axis)
             dcn_mesh_shape = (dcn_axis, 1)
+            logger.info(f"Multi-slice sharding: ici={ici_mesh_shape}, dcn={dcn_mesh_shape}")
             spmd_mesh = xs.HybridMesh(ici_mesh_shape=ici_mesh_shape, dcn_mesh_shape=dcn_mesh_shape, axis_names=('fsdp', 'tensor'))
         xs.set_global_mesh(spmd_mesh)
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -698,6 +698,11 @@ def main():
             checkpoint = training_args.resume_from_checkpoint
         elif last_checkpoint is not None:
             checkpoint = last_checkpoint
+
+        # Initialize ptxla megascale
+        torch_xla._XLAC._init_computation_client()
+        # Disable jax megascale
+        os.environ['USE_SINGLE_SLICE'] = 'true'
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         trainer.save_model()  # Saves the tokenizer too for easy upload
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -549,8 +549,19 @@ def main():
         from torch_xla.distributed.fsdp import checkpoint_module
         for i, block in enumerate(model.model.layers):
             model.model.layers[i] = checkpoint_module(block)
+
+        import torch_xla.debug.metrics as met
+        print("=================== Start metrics before materializing model ===================")
+        print(met.metrics_report())
+        print("=================== End metrics before materializing model ===================")
+
         # materialize all weights after 2d sharding
         torch_xla.sync()
+
+        import torch_xla.debug.metrics as met
+        print("=================== Start metrics after materializing model ===================")
+        print(met.metrics_report())
+        print("=================== End metrics after materializing model ===================")
 
     # Preprocessing the datasets.
     # First we tokenize all the texts.

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -791,6 +791,7 @@ def main():
         # Initialize ptxla megascale
         torch_xla._XLAC._init_computation_client()
         # Disable jax megascale
+        os.environ['SKIP_MEGASCALE_PJRT_CLIENT'] = 'true'
         os.environ['USE_SINGLE_SLICE'] = 'true'
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         trainer.save_model()  # Saves the tokenizer too for easy upload

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -550,6 +550,7 @@ def main():
             dict_of_params[name] = param
 
         model.load_state_dict(dict_of_params, assign=True)
+        model.to('xla')
         for i, block in enumerate(model.model.layers):
             xs.apply_backward_optimization_barrier(model.model.layers[i])
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -485,6 +485,11 @@ def main():
     if num_slices > 1 and model_args.spmd_2d_sharding == 0:
         raise ValueError("Multi-slice training requires SPMD 2D sharding")
 
+    import torch_xla.debug.metrics as met
+    print("=================== Start metrics before materializing model ===================")
+    print(met.metrics_report())
+    print("=================== End metrics before materializing model ===================")
+
     # Apply 2D sharding.
     # We apply sharding annotations before running the tokenizer, since
     # `training_args.main_process_first` may involve a `mark_step` which will materialize the
@@ -560,18 +565,13 @@ def main():
         for i, block in enumerate(model.model.layers):
             model.model.layers[i] = checkpoint_module(block)
 
-        import torch_xla.debug.metrics as met
-        print("=================== Start metrics before materializing model ===================")
-        print(met.metrics_report())
-        print("=================== End metrics before materializing model ===================")
-
         # materialize all weights after 2d sharding
         torch_xla.sync()
 
-        import torch_xla.debug.metrics as met
-        print("=================== Start metrics after materializing model ===================")
-        print(met.metrics_report())
-        print("=================== End metrics after materializing model ===================")
+    import torch_xla.debug.metrics as met
+    print("=================== Start metrics after materializing model ===================")
+    print(met.metrics_report())
+    print("=================== End metrics after materializing model ===================")
 
     # Preprocessing the datasets.
     # First we tokenize all the texts.

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -56,6 +56,7 @@ from transformers.utils.versions import require_version
 import torch_xla
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+import torch_xla.core.xla_model as xm
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.46.0.dev0")

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -542,11 +542,6 @@ def main():
 
             print(f'{name} {torch_xla._XLAC._get_xla_sharding_spec(param)}')
             torch_xla.sync()
-
-            # See https://github.com/huggingface/transformers/issues/34234.
-            if "rotary_emb.inv_freq" in name:
-                # Otherwise, we get error: Unexpected key(s) in state_dict: "model.layers.0.self_attn.rotary_emb.inv_freq",
-                continue
             dict_of_params[name] = param
 
         model.load_state_dict(dict_of_params, assign=True)

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -64,8 +64,6 @@ require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/lan
 
 logger = logging.getLogger(__name__)
 
-torch.set_default_dtype(torch.bfloat16)
-
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -572,8 +572,8 @@ def main():
             model.config.use_cache = False
             
         # Activate scan
-        # model.model.unroll_decoders = False
-        model.model.unroll_decoders = True
+        model.model.unroll_decoders = False
+        # model.model.unroll_decoders = True
 
         # Materialize all weights after 2d sharding
         torch_xla.sync()

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -542,6 +542,11 @@ def main():
 
             print(f'{name} {torch_xla._XLAC._get_xla_sharding_spec(param)}')
             torch_xla.sync()
+
+            # See https://github.com/huggingface/transformers/issues/34234.
+            if "rotary_emb.inv_freq" in name:
+                # Otherwise, we get error: Unexpected key(s) in state_dict: "model.layers.0.self_attn.rotary_emb.inv_freq",
+                continue
             dict_of_params[name] = param
 
         model.load_state_dict(dict_of_params, assign=True)

--- a/fsdp_config.json
+++ b/fsdp_config.json
@@ -1,0 +1,8 @@
+{
+    "fsdp_transformer_layer_cls_to_wrap": [
+        "LlamaDecoderLayer"
+    ],
+    "xla": true,
+    "xla_fsdp_v2": true,
+    "xla_fsdp_grad_ckpt": false
+}

--- a/src/transformers/models/llama/aot_flash_attention.py
+++ b/src/transformers/models/llama/aot_flash_attention.py
@@ -31,8 +31,7 @@ def defeat_device_data(v):
   Use this function to stop a tensor from become device data, so that sharding
   annotations may be applied.
   """
-  epsilon = 1e-9
-  return v + epsilon
+  return v
 
 
 def describe_value(v):

--- a/src/transformers/models/llama/aot_flash_attention.py
+++ b/src/transformers/models/llama/aot_flash_attention.py
@@ -1,0 +1,607 @@
+import torch
+import torch_xla
+from typing import List
+import functools
+import os
+import warnings
+
+import numpy as np
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.debug.metrics as met
+
+from typing import Any, List, Callable, Optional, Tuple, Dict
+from torch.library import impl, custom_op
+from torch_xla.core.xla_model import XLA_LIB
+from torch_xla.experimental.custom_kernel import FlashAttention
+
+_XLA_USE_BF16 = os.environ.get("XLA_USE_BF16", "0") == "1"
+
+_DEBUG = False
+
+
+def describe_value(v):
+  if v is not None and isinstance(v, torch.Tensor):
+    print(f"{type(v)}({v.shape}, dtype={v.dtype}, device={v.device})")
+  elif isinstance(v, list):
+    print(f"list({len(v)})")
+  elif v is None:
+    print("None")
+  else:
+    print(type(v))
+
+
+def _extract_backend_config(
+    module: "jaxlib.mlir._mlir_libs._mlir.ir.Module") -> Optional[str]:
+  """
+  This algorithm intends to extract the backend config from the compiler IR like the following,
+  and it is not designed to traverse any generic MLIR module.
+
+  module @jit_add_vectors attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+    func.func public @main(%arg0: tensor<8xi32> {mhlo.layout_mode = "default", mhlo.sharding = "{replicated}"}, %arg1: tensor<8xi32> {mhlo.layout_mode = "default", mhlo.sharding = "{replicated}"}) -> (tensor<8xi32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
+      %0 = call @add_vectors(%arg0, %arg1) : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+      return %0 : tensor<8xi32>
+    }
+    func.func private @add_vectors(%arg0: tensor<8xi32>, %arg1: tensor<8xi32>) -> tensor<8xi32> {
+      %0 = call @wrapped(%arg0, %arg1) : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+      return %0 : tensor<8xi32>
+    }
+    func.func private @wrapped(%arg0: tensor<8xi32>, %arg1: tensor<8xi32>) -> tensor<8xi32> {
+      %0 = call @apply_kernel(%arg0, %arg1) : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+      return %0 : tensor<8xi32>
+    }
+    func.func private @apply_kernel(%arg0: tensor<8xi32>, %arg1: tensor<8xi32>) -> tensor<8xi32> {
+      %0 = stablehlo.custom_call @tpu_custom_call(%arg0, %arg1) {backend_config = "{\22custom_call_config\22: {\22body\22: \22TUzvUgFNTElSMTkuMC4wZ2l0AAErCwEDBQcJAQMLAwUDDQcFDxEJBRMVA3lZDQFVBwsPEw8PCw8PMwsLCwtlCwsLCwsPCw8PFw8LFw8PCxcPCxcTCw8LDxcLBQNhBwNZAQ0bBxMPGw8CagMfBRcdKy0DAycpHVMREQsBBRkVMzkVTw8DCxUXGRsfCyELIyUFGwEBBR0NCWFmZmluZV9tYXA8KGQwKSAtPiAoZDApPgAFHwUhBSMFJQUnEQMBBSkVLw8dDTEXA8IfAR01NwUrFwPWHwEVO0EdPT8FLRcD9h8BHUNFBS8XA3InAQMDSVcFMR1NEQUzHQ1RFwPGHwEFNSN0cHUubWVtb3J5X3NwYWNlPHZtZW0+ACNhcml0aC5vdmVyZmxvdzxub25lPgAXVQMhBx0DJwMhBwECAgUHAQEBAQECBASpBQEQAQcDAQUDEQETBwMVJwcBAQEBAQEHAwUHAwMLBgUDBQUBBwcDBQcDAwsGBQMFBQMLCQdLRwMFBQkNBwMJBwMDCwYJAwUFBRENBAkHDwURBQABBgMBBQEAxgg32wsdE2EZ2Q0LEyMhHSknaw0LCxMPDw8NCQsRYnVpbHRpbgBmdW5jAHRwdQBhcml0aAB2ZWN0b3IAbW9kdWxlAHJldHVybgBjb25zdGFudABhZGRpAGxvYWQAc3RvcmUAL3dvcmtzcGFjZXMvd29yay9weXRvcmNoL3hsYS90ZXN0L3Rlc3Rfb3BlcmF0aW9ucy5weQBhZGRfdmVjdG9yc19rZXJuZWwAZGltZW5zaW9uX3NlbWFudGljcwBmdW5jdGlvbl90eXBlAHNjYWxhcl9wcmVmZXRjaABzY3JhdGNoX29wZXJhbmRzAHN5bV9uYW1lAG1haW4AdmFsdWUAL2dldFt0cmVlPVB5VHJlZURlZigoQ3VzdG9tTm9kZShOREluZGV4ZXJbKFB5VHJlZURlZigoQ3VzdG9tTm9kZShTbGljZVsoMCwgOCldLCBbXSksKSksICg4LCksICgpKV0sIFtdKSwpKV0AYWRkX3ZlY3RvcnMAdGVzdF90cHVfY3VzdG9tX2NhbGxfcGFsbGFzX2V4dHJhY3RfYWRkX3BheWxvYWQAPG1vZHVsZT4Ab3ZlcmZsb3dGbGFncwAvYWRkAC9zd2FwW3RyZWU9UHlUcmVlRGVmKChDdXN0b21Ob2RlKE5ESW5kZXhlclsoUHlUcmVlRGVmKChDdXN0b21Ob2RlKFNsaWNlWygwLCA4KV0sIFtdKSwpKSwgKDgsKSwgKCkpXSwgW10pLCkpXQA=\22, \22needs_layout_passes\22: true}}", kernel_name = "add_vectors_kernel", operand_layouts = [dense<0> : tensor<1xindex>, dense<0> : tensor<1xindex>], result_layouts = [dense<0> : tensor<1xindex>]} : (tensor<8xi32>, tensor<8xi32>) -> tensor<8xi32>
+      return %0 : tensor<8xi32>
+    }
+  }
+
+  Basically, what we are looking for is a two level of operations, and the tpu_custom_call operation in the inner level. It will return None if the payload is not found.
+  """
+  for operation in module.body.operations:
+    assert len(
+        operation.body.blocks) == 1, "The passing module is not compatible."
+    for op in operation.body.blocks[0].operations:
+      if op.name == "stablehlo.custom_call":
+        return op.backend_config.value
+  return None
+
+
+def jax_import_guard():
+  # Somehow, we need to grab the TPU before JAX locks it. Otherwise, any pt-xla TPU operations will hang.
+  torch_xla._XLAC._init_computation_client()
+
+
+def convert_torch_dtype_to_jax(dtype: torch.dtype) -> "jnp.dtype":
+  # Import JAX within the function such that we don't need to call the jax_import_guard()
+  # in the global scope which could cause problems for xmp.spawn.
+  jax_import_guard()
+  import jax.numpy as jnp
+  if _XLA_USE_BF16:
+    raise RuntimeError(
+        "Pallas kernel does not support XLA_USE_BF16, please unset the env var")
+  if dtype == torch.float32:
+    return jnp.float32
+  elif dtype == torch.float64:
+    return jnp.float64
+  elif dtype == torch.float16:
+    return jnp.float16
+  elif dtype == torch.bfloat16:
+    return jnp.bfloat16
+  elif dtype == torch.int32:
+    return jnp.int32
+  elif dtype == torch.int64:
+    return jnp.int64
+  elif dtype == torch.int16:
+    return jnp.int16
+  elif dtype == torch.int8:
+    return jnp.int8
+  elif dtype == torch.uint8:
+    return jnp.uint8
+  else:
+    raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+def to_jax_shape_dtype_struct(tensor: torch.Tensor) -> "jax.ShapeDtypeStruct":
+  # Import JAX within the function such that we don't need to call the jax_import_guard()
+  # in the global scope which could cause problems for xmp.spawn.
+  jax_import_guard()
+  import jax
+
+  return jax.ShapeDtypeStruct(tensor.shape,
+                              convert_torch_dtype_to_jax(tensor.dtype))
+
+
+trace_pallas_arg_to_payload: Dict[Tuple[Any], str] = {}
+
+
+def trace_pallas(kernel: Callable,
+                 *args,
+                 static_argnums=None,
+                 static_argnames=None,
+                 use_cache=False,
+                 **kwargs):
+  # Import JAX within the function such that we don't need to call the jax_import_guard()
+  # in the global scope which could cause problems for xmp.spawn.
+  jax_import_guard()
+  import jax
+  import jax._src.pallas.mosaic.pallas_call_registration
+
+  jax_args = []  # for tracing
+  tensor_args = []  # for execution
+  for i, arg in enumerate(args):
+    # TODO: Could the args be a tuple of tensors or a list of tensors? Flattern them?
+    if torch.is_tensor(arg):
+      # ShapeDtypeStruct doesn't have any storage and thus is very suitable for generating the payload.
+      jax_meta_tensor = to_jax_shape_dtype_struct(arg)
+      jax_args.append(jax_meta_tensor)
+      tensor_args.append(arg)
+    else:
+      jax_args.append(arg)
+
+  hash_key = ()
+  if use_cache:
+    global trace_pallas_arg_to_payload
+    # implcit assumption here that everything in kwargs is hashable and not a tensor,
+    # which is true for the gmm and tgmm.
+    hash_key = (jax.config.jax_default_matmul_precision, kernel, static_argnums,
+                tuple(static_argnames)
+                if static_argnames is not None else static_argnames,
+                tuple(jax_args), repr(sorted(kwargs.items())).encode())
+    if hash_key in trace_pallas_arg_to_payload:
+      torch_xla._XLAC._xla_increment_counter('trace_pallas_cache_hit', 1)
+      return trace_pallas_arg_to_payload[hash_key], tensor_args
+
+  # Here we ignore the kwargs for execution as most of the time, the kwargs is only used in traced code.
+  ir = jax.jit(
+      kernel, static_argnums=static_argnums,
+      static_argnames=static_argnames).lower(*jax_args, **kwargs).compiler_ir()
+  payload = _extract_backend_config(ir)
+
+  if use_cache:
+    # if we reach here it means we have a cache miss.
+    trace_pallas_arg_to_payload[hash_key] = payload
+
+  return payload, tensor_args
+
+
+def make_kernel_from_pallas(kernel: Callable, output_shape_dtype_fn: Callable):
+  # TODO: Maybe we can cache the payload for the same input.
+  def wrapped_kernel(kernel: Callable,
+                     output_shape_dtype_fn: Callable,
+                     *args,
+                     static_argnums=None,
+                     static_argnames=None,
+                     **kwargs) -> Callable:
+    payload, tensor_args = trace_pallas(
+        kernel,
+        *args,
+        static_argnums=static_argnums,
+        static_argnames=static_argnames,
+        **kwargs)
+    output_shape_dtype = output_shape_dtype_fn(*args)
+    assert isinstance(output_shape_dtype,
+                      list), "The output_shape_dtype_fn should return a list."
+    output_shapes = [shape for shape, _ in output_shape_dtype]
+    output_dtypes = [dtype for _, dtype in output_shape_dtype]
+    outputs = torch_xla._XLAC._xla_tpu_custom_call(tensor_args, payload,
+                                                   output_shapes, output_dtypes)
+
+    # Make the output easier to use.
+    if len(outputs) == 1:
+      return outputs[0]
+    return tuple(outputs)
+
+  return functools.partial(wrapped_kernel, kernel, output_shape_dtype_fn)
+
+
+@custom_op("xla::fa_custom_forward", mutates_args=())
+def fa_custom_forward(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+           torch.Tensor]:
+  q = q.clone()
+  k = k.clone()
+  v = v.clone()
+
+  partition_spec = ('fsdp', 'tensor', None, None)
+  mesh = xs.get_global_mesh()
+  assert mesh is not None
+
+  if _DEBUG:
+    print("Inside fa_custom_forward")
+    for t in [q, k, v]:
+      describe_value(t)
+
+  q_segment_ids = kv_segment_ids = ab = None
+  sm_scale = 1.0
+  causal = True
+
+  # Import JAX within the function such that we don't need to call the jax_import_guard()
+  # in the global scope which could cause problems for xmp.spawn.
+  jax_import_guard()
+  import jax
+  from jax.experimental.pallas.ops.tpu.flash_attention import _flash_attention_impl
+
+  q_full_shape = None
+  kv_full_shape = None
+  save_residuals = True
+
+  # SPMD integration.
+  # mark_sharding is in-placed, and therefore save the full q, k, v for the backward.
+  # PyTorch tell us clone is necessary:
+  #
+  # RuntimeError: Found a custom (non-ATen) operator whose output has alias
+  # annotations: xla::fa_custom_forward(Tensor(a0!) q, Tensor(a1!) k,
+  # Tensor(a2!) v) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor). We only
+  # support functionalizing operators whose outputs do not have alias
+  # annotations (e.g. 'Tensor(a)' is a Tensor with an alias annotation whereas
+  # 'Tensor' is a Tensor without. The '(a)' is the alias annotation). The alias
+  # annotation specifies that the output Tensor shares storage with an input
+  # that has the same annotation. Please check if (1) the output needs to be an
+  # output (if not, don't return it), (2) if the output doesn't share storage
+  # with any inputs, then delete the alias annotation. (3) if the output indeed
+  # shares storage with an input, then add a .clone() before returning it to
+  # prevent storage sharing and then delete the alias annotation. Otherwise,
+  # please file an issue on GitHub.
+  #
+  full_q = q.clone()
+  full_k = k.clone()
+  full_v = v.clone()
+  full_ab = ab
+  if partition_spec is not None:
+    q_full_shape = q.shape
+    kv_full_shape = k.shape
+    q = xs.enable_manual_sharding(q, partition_spec, mesh=mesh).global_tensor
+    k = xs.enable_manual_sharding(k, partition_spec, mesh=mesh).global_tensor
+    v = xs.enable_manual_sharding(v, partition_spec, mesh=mesh).global_tensor
+    if ab:
+      ab = xs.enable_manual_sharding(
+          ab, partition_spec, mesh=mesh).global_tensor
+
+  # It computes the shape and type of o, l, m.
+  shapes = [q.shape]
+  dtypes = [q.dtype]
+  if save_residuals:
+    res_shape = list(q.shape)
+    res_shape[-1] = FlashAttention.MIN_BLOCK_SIZE
+    for _ in range(2):
+      shapes.append(res_shape)
+      dtypes.append(torch.float32)
+
+  with torch.no_grad():
+    if partition_spec is not None and q_segment_ids is not None and kv_segment_ids is not None:
+      # partition_spec is for q,k,v with shape [batch, num_head, seq_len, head_dim], segment id
+      # is of shape [batch, seq_len], hence we need to tweak it a bit
+      segment_id_partition_spec = (partition_spec[0], partition_spec[2])
+      q_segment_ids = xs.enable_manual_sharding(
+          q_segment_ids, segment_id_partition_spec, mesh=mesh).global_tensor
+      kv_segment_ids = xs.enable_manual_sharding(
+          kv_segment_ids, segment_id_partition_spec, mesh=mesh).global_tensor
+    segment_ids, q_segment_ids_fa, kv_segment_ids_fa = FlashAttention.prepare_segment_ids(
+        q_segment_ids, kv_segment_ids)
+
+    # We can't directly use flash_attention as we need to override the save_residuals flag which returns
+    # l and m that is needed for the backward. Then we lose all the shape checks.
+    # TODO: replicate the shape checks on flash_attention.
+    # Here we seperate the tracing and execution part just to support SegmentIds.
+    payload, _ = trace_pallas(
+        _flash_attention_impl,
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        save_residuals,
+        causal,
+        sm_scale,
+        min(FlashAttention.DEFAULT_BLOCK_SIZES["block_b"], q.shape[0]),
+        min(FlashAttention.DEFAULT_BLOCK_SIZES["block_q"], q.shape[2]),
+        min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major"], k.shape[2]),
+        min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k"], k.shape[2]),
+        False,
+        static_argnums=range(5, 13),
+        use_cache=True,
+    )
+
+    args = [q, k, v]
+    if ab is not None:
+      args += [ab]
+    if segment_ids is not None:
+      args += [q_segment_ids_fa, kv_segment_ids_fa]
+    o = torch_xla._XLAC._xla_tpu_custom_call(args, payload, shapes, dtypes)
+
+    if not save_residuals:
+      o = o[0]
+      # SPMD integration
+      if partition_spec is not None:
+        o = xs.disable_manual_sharding(
+            o, partition_spec, q_full_shape, mesh=mesh).global_tensor
+      return o
+    o, *aux = o
+    l, m = (v[..., 0] for v in aux[-2:])
+
+  # SPMD integration
+  if partition_spec is not None:
+    o = xs.disable_manual_sharding(
+        o, partition_spec, q_full_shape, mesh=mesh).global_tensor
+    l = xs.disable_manual_sharding(
+        l, partition_spec[0:3], q_full_shape[0:3], mesh=mesh).global_tensor
+    m = xs.disable_manual_sharding(
+        m, partition_spec[0:3], q_full_shape[0:3], mesh=mesh).global_tensor
+
+  assert partition_spec is not None
+
+  # TODO: this causes !IsManual() assertion
+  # xs.mark_sharding(full_q, mesh, partition_spec)
+  # xs.mark_sharding(full_k, mesh, partition_spec)
+  # xs.mark_sharding(full_v, mesh, partition_spec)
+  # xs.mark_sharding(o, mesh, partition_spec)
+  # xs.mark_sharding(l, mesh, partition_spec[:3])
+  # xs.mark_sharding(m, mesh, partition_spec[:3])
+
+  # q_segment_ids and kv_segment_ids are sharded here if partition_spec is provided
+  # but it should be OK as the backward will use the same partition_spec
+  outs = [o] + [full_q, full_k, full_v, l, m]
+  if _DEBUG:
+    print("Outs")
+    for t in outs:
+      describe_value(t)
+  return tuple(outs)
+
+
+@fa_custom_forward.register_fake
+def fa_custom_forward_fake(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor):
+  if _DEBUG:
+    print("Inside fake fa_custom_forward")
+
+  assert q.shape == k.shape
+  assert k.shape == v.shape
+
+  # full_q, full_k, full_v, o, l, m
+  full_q = torch.empty_like(q)
+  full_k = torch.empty_like(k)
+  full_v = torch.empty_like(v)
+  o = torch.empty_like(v)
+  l = torch.empty_like(v, dtype=torch.float32)[..., 0]
+  m = torch.empty_like(v, dtype=torch.float32)[..., 0]
+
+  return tuple([torch.empty_like(o)] +
+               [torch.empty_like(t) for t in (
+                   full_q,
+                   full_k,
+                   full_v,
+                   l,
+                   m,
+               )])
+
+
+@custom_op("xla::fa_custom_backward", mutates_args=())
+def fa_custom_backward(
+    grad_output: torch.Tensor, q: torch.Tensor, k: torch.Tensor,
+    v: torch.Tensor, o: torch.Tensor, l: torch.Tensor, m: torch.Tensor,
+    q_shape: List[int],
+    k_shape: List[int]) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  q_segment_ids_fa = kv_segment_ids_fa = ab = None
+
+  partition_spec = ('fsdp', 'tensor', None, None)
+  mesh = xs.get_global_mesh()
+  assert mesh is not None
+
+  # TODO: this causes !IsManual() assertion
+  # xs.mark_sharding(q, mesh, partition_spec)
+  # xs.mark_sharding(k, mesh, partition_spec)
+  # xs.mark_sharding(v, mesh, partition_spec)
+  # xs.mark_sharding(o, mesh, partition_spec)
+  # xs.mark_sharding(l, mesh, partition_spec[:3])
+  # xs.mark_sharding(m, mesh, partition_spec[:3])
+
+  if _DEBUG:
+    print("Inside fa_custom_backward")
+
+  from jax.experimental.pallas.ops.tpu.flash_attention import _flash_attention_bwd_dq, _flash_attention_bwd_dkv
+
+  saved_tensors = (q, k, v, o, l, m)
+  q, k, v, o, l, m = (t for t in saved_tensors)
+  causal = True
+  sm_scale = 1.0
+  q_full_shape = torch.Size(q_shape)
+  kv_full_shape = torch.Size(k_shape)
+  # this segment_ids only reflects the local shape of segment_ids
+  segment_ids = None
+  grad_q = grad_k = grad_v = grad_ab = None
+  needs_input_grad = [True, True, True]
+  grad_i = torch.sum(
+      o.to(torch.float32) * grad_output.to(torch.float32),
+      axis=-1)  # [batch_size, num_heads, q_seq_len]
+
+  expanded_l = l.unsqueeze(-1).expand([-1 for _ in l.shape] +
+                                      [FlashAttention.MIN_BLOCK_SIZE])
+  expanded_m = m.unsqueeze(-1).expand([-1 for _ in m.shape] +
+                                      [FlashAttention.MIN_BLOCK_SIZE])
+  expanded_grad_i = grad_i.unsqueeze(-1).expand([-1 for _ in grad_i.shape] +
+                                                [FlashAttention.MIN_BLOCK_SIZE])
+
+  # SPMD integration
+  if partition_spec is not None:
+    q = xs.enable_manual_sharding(q, partition_spec, mesh=mesh).global_tensor
+    k = xs.enable_manual_sharding(k, partition_spec, mesh=mesh).global_tensor
+    v = xs.enable_manual_sharding(v, partition_spec, mesh=mesh).global_tensor
+    expanded_l = xs.enable_manual_sharding(
+        expanded_l, partition_spec, mesh=mesh).global_tensor
+    expanded_m = xs.enable_manual_sharding(
+        expanded_m, partition_spec, mesh=mesh).global_tensor
+    grad_output = xs.enable_manual_sharding(
+        grad_output, partition_spec, mesh=mesh).global_tensor
+    expanded_grad_i = xs.enable_manual_sharding(
+        expanded_grad_i, partition_spec, mesh=mesh).global_tensor
+    if ab:
+      ab = xs.enable_manual_sharding(
+          ab, partition_spec, mesh=mesh).global_tensor
+
+  if needs_input_grad[0]:
+    payload, _ = trace_pallas(
+        _flash_attention_bwd_dq,
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        l,
+        m,
+        grad_output,
+        grad_i,
+        block_q_major=min(FlashAttention.DEFAULT_BLOCK_SIZES["block_q_dq"],
+                          q.shape[2]),
+        block_k_major=min(
+            FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major_dq"], k.shape[2]),
+        block_k=min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_dq"],
+                    k.shape[2]),
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=FlashAttention.DEFAULT_MASK_VALUE,
+        debug=False,
+        static_argnames=[
+            "block_q_major", "block_k_major", "block_k", "sm_scale", "causal",
+            "mask_value", "debug"
+        ],
+        use_cache=True,
+    )
+
+    args = [q, k, v]
+    if ab is not None:
+      args += [ab]
+    if segment_ids is not None:
+      args += [q_segment_ids_fa, kv_segment_ids_fa]
+    args += [expanded_l, expanded_m, grad_output, expanded_grad_i]
+
+    outputs = [q]
+    if ab is not None:
+      outputs += [ab]
+    grads = torch_xla._XLAC._xla_tpu_custom_call(args, payload,
+                                                 [i.shape for i in outputs],
+                                                 [i.dtype for i in outputs])
+    if needs_input_grad[0]:
+      grad_q = grads[0]
+
+  if needs_input_grad[1] or needs_input_grad[2]:
+    payload, _ = trace_pallas(
+        _flash_attention_bwd_dkv,
+        q,
+        k,
+        v,
+        ab,
+        segment_ids,
+        l,
+        m,
+        grad_output,
+        grad_i,
+        block_q_major=min(
+            FlashAttention.DEFAULT_BLOCK_SIZES["block_q_major_dkv"],
+            q.shape[2]),
+        block_k_major=min(
+            FlashAttention.DEFAULT_BLOCK_SIZES["block_k_major_dkv"],
+            k.shape[2]),
+        block_k=min(FlashAttention.DEFAULT_BLOCK_SIZES["block_k_dkv"],
+                    k.shape[2]),
+        block_q=min(FlashAttention.DEFAULT_BLOCK_SIZES["block_q_dkv"],
+                    q.shape[2]),
+        sm_scale=sm_scale,
+        causal=causal,
+        mask_value=FlashAttention.DEFAULT_MASK_VALUE,
+        debug=False,
+        static_argnames=[
+            "block_q_major", "block_k_major", "block_k", "block_q", "sm_scale",
+            "causal", "mask_value", "debug"
+        ],
+        use_cache=True)
+
+    grads = torch_xla._XLAC._xla_tpu_custom_call(args, payload,
+                                                 [k.shape, v.shape],
+                                                 [k.dtype, v.dtype])
+
+  if needs_input_grad[1]:
+    grad_k = grads[0]
+  if needs_input_grad[2]:
+    grad_v = grads[1]
+
+  # SPMD integration
+  if partition_spec is not None:
+    grad_q = xs.disable_manual_sharding(
+        grad_q, partition_spec, q_full_shape, mesh=mesh).global_tensor
+    grad_k = xs.disable_manual_sharding(
+        grad_k, partition_spec, kv_full_shape, mesh=mesh).global_tensor
+    grad_v = xs.disable_manual_sharding(
+        grad_v, partition_spec, kv_full_shape, mesh=mesh).global_tensor
+
+  assert partition_spec is not None
+
+  return grad_q, grad_k, grad_v
+
+
+@fa_custom_backward.register_fake
+def fa_custom_backward_fake(grad_output, q, k, v, o, l, m, q_shape, k_shape):
+  if _DEBUG:
+    print("Inside fake fa_custom_backward")
+  return torch.empty_like(grad_output), torch.empty_like(
+      grad_output), torch.empty_like(grad_output)
+
+
+class FlashAttention2(torch.autograd.Function):
+
+  @staticmethod
+  def forward(ctx, q, k, v):
+    with torch.no_grad():
+      ctx.q_shape = q.shape
+      ctx.k_shape = k.shape
+
+      q = q.clone().detach()
+      k = k.clone().detach()
+      v = v.clone().detach()
+      outs = torch.ops.xla.fa_custom_forward(q, k, v)
+      if _DEBUG:
+        print("forward done with fa_custom_forward")
+
+      o = outs[0]
+      full_q, full_k, full_v, l, m = [x.detach() for x in outs[1:]]
+
+      # q_segment_ids and kv_segment_ids are sharded here if partition_spec is provided
+      # but it should be OK as the backward will use the same partition_spec
+      ctx.save_for_backward(full_q, full_k, full_v, o.detach(), l, m)
+      return o
+
+  @staticmethod
+  def backward(ctx, grad_output):
+    with torch.no_grad():
+      grad_ab = None
+      if _DEBUG:
+        print("Inside backward")
+
+      saved = [v.detach() for v in ctx.saved_tensors]
+      if _DEBUG:
+        for t in [grad_output] + saved:
+          describe_value(t)
+
+      return torch.ops.xla.fa_custom_backward(grad_output.detach(), *saved,
+                                              list(ctx.q_shape),
+                                              list(ctx.k_shape))
+
+
+def flash_attention_2(
+    q,  # [batch_size, num_heads, q_seq_len, d_model]
+    k,  # [batch_size, num_heads, kv_seq_len, d_model]
+    v,  # [batch_size, num_heads, kv_seq_len, d_model]
+    causal=False,
+    q_segment_ids=None,  # [batch_size, q_seq_len]
+    kv_segment_ids=None,
+    sm_scale=1.0,
+    *,
+    ab=None,  # [batch_size, num_heads, q_seq_len, kv_seq_len]
+    partition_spec=None,
+    mesh=None,
+):
+  assert causal, "causal must be True"
+  assert partition_spec == ('fsdp', 'tensor', None, None)
+  return FlashAttention2.apply(q, k, v)

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -167,6 +167,7 @@ class LlamaConfig(PretrainedConfig):
         mlp_bias=False,
         head_dim=None,
         unroll_decoders=False,
+        scan_bw_output_sharder=None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -194,6 +195,7 @@ class LlamaConfig(PretrainedConfig):
         self.head_dim = head_dim if head_dim is not None else self.hidden_size // self.num_attention_heads
 
         self.unroll_decoders = unroll_decoders
+        self.scan_bw_output_sharder = scan_bw_output_sharder
 
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, copy it it to 'rope_type'.

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -166,6 +166,7 @@ class LlamaConfig(PretrainedConfig):
         attention_dropout=0.0,
         mlp_bias=False,
         head_dim=None,
+        unroll_decoders=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -191,6 +192,9 @@ class LlamaConfig(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.mlp_bias = mlp_bias
         self.head_dim = head_dim if head_dim is not None else self.hidden_size // self.num_attention_heads
+
+        self.unroll_decoders = unroll_decoders
+
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, copy it it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:

--- a/src/transformers/models/llama/graph_transforms/offloading.py
+++ b/src/transformers/models/llama/graph_transforms/offloading.py
@@ -58,11 +58,14 @@ def remat_all_and_offload_these_inputs(
 
   fw_name_in_output_indices = get_name_in_output_indices(fwd)
   bw_name_in_input_names = get_name_in_input_names(bwd)
-
+  
   for name in names_to_offload:
     print(f"Going to offload {name}")
     assert name in fw_name_in_output_indices
     assert name in bw_name_in_input_names
+    
+  print("fw_name_in_output_indices", fw_name_in_output_indices)
+  print("bw_name_in_input_names", bw_name_in_input_names)
 
   with torch.no_grad():
 

--- a/src/transformers/models/llama/graph_transforms/offloading.py
+++ b/src/transformers/models/llama/graph_transforms/offloading.py
@@ -60,6 +60,7 @@ def remat_all_and_offload_these_inputs(
   bw_name_in_input_names = get_name_in_input_names(bwd)
 
   for name in names_to_offload:
+    print(f"Going to offload {name}")
     assert name in fw_name_in_output_indices
     assert name in bw_name_in_input_names
 

--- a/src/transformers/models/llama/graph_transforms/offloading.py
+++ b/src/transformers/models/llama/graph_transforms/offloading.py
@@ -82,6 +82,9 @@ def remat_all_and_offload_these_inputs(
         pdb.post_mortem()
 
     def backward(**kwargs):
+      print(f"Backward got {len(kwargs)} arguments:")
+      for k, v in kwargs.items():
+        print(f"Arg {k}: {v.shape if v is not None else 'None'}")
       arguments_to_move_back = set(
           [bw_name_in_input_names[name] for name in names_to_offload])
       kwargs = {
@@ -90,7 +93,11 @@ def remat_all_and_offload_these_inputs(
       }
       import pdb
       try:
-        return bwd(**kwargs)
+        values = bwd(**kwargs)
+        print(f"Backward will return {len(values)} values:")
+        for i, v in enumerate(values):
+          print(f"Arg {i}: {v.shape if v is not None else 'None'}")
+        return values
       except Exception:
         pdb.post_mortem()
 

--- a/src/transformers/models/llama/graph_transforms/offloading.py
+++ b/src/transformers/models/llama/graph_transforms/offloading.py
@@ -1,0 +1,164 @@
+from typing import Sequence
+import torch.fx as fx
+import torch
+import torch_xla
+
+from functorch.compile import aot_function, make_boxed_func  # type:ignore
+from .remat_all import remat_all_partition_fn
+
+
+@torch.library.custom_op("xla::offload_name", mutates_args=())
+def offload_name(t: torch.Tensor, name: str) -> torch.Tensor:
+  """
+  `offload_name` is an identity function that associates the input
+  tensor with `name`. It is primarily useful in conjunction with
+  `remat_all_and_offload_these_inputs`, which will rematerialize
+  intermediate activations and also offload inputs with the specified
+  names to host memory, moving them back during the backward pass.
+  """
+  if t is None:
+    return None
+  return t.clone()
+
+
+@offload_name.register_fake
+def _(t: torch.Tensor, name: str) -> torch.Tensor:
+  if t is None:
+    return None
+  return torch.empty_like(t)
+
+
+def offload_name_backward(ctx, grad):
+  return grad, None
+
+
+offload_name.register_autograd(offload_name_backward)
+
+
+def remat_all_and_offload_these_inputs(
+    joint_module: fx.GraphModule,
+    _joint_inputs,
+    *,
+    num_fwd_outputs,
+    names_to_offload: Sequence[str],
+):
+  """
+  `remat_all_and_offload_these_inputs` will rematerialize (recompute) all
+  intermediate activations in `joint_module`, and offload inputs with the
+  specified names to host memory, moving them back during the backward pass.
+  It transforms the joint graph into separate forward and backward graphs.
+  """
+  fwd, bwd = remat_all_partition_fn(
+      joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs)
+  with torch.device('meta'):
+    fw_example_args = make_arguments(fwd)
+    bw_example_args = make_arguments(bwd)
+
+  fw_name_in_output_indices = get_name_in_output_indices(fwd)
+  bw_name_in_input_names = get_name_in_input_names(bwd)
+
+  for name in names_to_offload:
+    assert name in fw_name_in_output_indices
+    assert name in bw_name_in_input_names
+
+  with torch.no_grad():
+
+    def forward(**kwargs):
+      import pdb
+      try:
+        out = fwd(**kwargs)
+        indices_to_offload = set(
+            [fw_name_in_output_indices[name] for name in names_to_offload])
+        return tuple(
+            torch.ops.xla.place_to_host(v) if i in  # type:ignore
+            indices_to_offload else v for i, v in enumerate(out))
+      except Exception:
+        pdb.post_mortem()
+
+    def backward(**kwargs):
+      arguments_to_move_back = set(
+          [bw_name_in_input_names[name] for name in names_to_offload])
+      kwargs = {
+          k: torch.ops.xla.place_to_device(v)  # type: ignore
+          if k in arguments_to_move_back else v for k, v in kwargs.items()
+      }
+      import pdb
+      try:
+        return bwd(**kwargs)
+      except Exception:
+        pdb.post_mortem()
+
+    # Use AOTAutograd to retrace forward and backward, thus incorporating
+    # the offloading ops.
+    graph = [None]
+
+    def get_graph(g, _):
+      graph[0] = g
+      return make_boxed_func(g)
+
+    _ = aot_function(forward, fw_compiler=get_graph)(**fw_example_args)
+    aot_forward = graph[0]
+
+    _ = aot_function(backward, fw_compiler=get_graph)(**bw_example_args)
+    aot_backward = graph[0]
+
+    return aot_forward, aot_backward
+
+
+def make_arguments(gm: fx.GraphModule):
+  """
+  Given a graph module, `make_arguments` returns a dictionary of example inputs
+  that can be used as keyward arguments to call the graph module.
+  """
+  example_args = {}
+  for node in gm.graph.nodes:
+    if node.op != 'placeholder':
+      continue
+    if 'tensor_meta' in node.meta:
+      tensor_meta = node.meta['tensor_meta']
+      tensor = torch.zeros(
+          tensor_meta.shape,
+          dtype=tensor_meta.dtype,
+          requires_grad=tensor_meta.requires_grad)
+      example_args[node.name] = tensor
+  return example_args
+
+
+def get_named_nodes(gm: torch.fx.GraphModule):
+  named_nodes = {}
+
+  for node in gm.graph.nodes:
+    if node.op == "call_function":
+      if hasattr(node.target, "name"):
+        if node.target.name() == offload_name._qualname:  # type: ignore
+          named_nodes[node.args[0]] = node.args[1]
+
+  return named_nodes
+
+
+def get_name_in_output_indices(gm: torch.fx.GraphModule):
+  named_nodes = get_named_nodes(gm)
+  name_in_output_indices = {}
+
+  for node in gm.graph.nodes:
+    if node.op == "output":
+      assert len(node.args) <= 1
+      if len(node.args) == 0:
+        continue
+      for i, arg in enumerate(next(iter(node.args))):  # type: ignore
+        if arg in named_nodes:
+          name_in_output_indices[named_nodes[arg]] = i
+
+  return name_in_output_indices
+
+
+def get_name_in_input_names(gm: torch.fx.GraphModule):
+  named_nodes = get_named_nodes(gm)
+  name_in_input_names = {}
+
+  for node in gm.graph.nodes:
+    if node.op == "placeholder":
+      if node in named_nodes:
+        name_in_input_names[named_nodes[node]] = node.target
+
+  return name_in_input_names

--- a/src/transformers/models/llama/graph_transforms/offloading.py
+++ b/src/transformers/models/llama/graph_transforms/offloading.py
@@ -2,6 +2,7 @@ from typing import Sequence
 import torch.fx as fx
 import torch
 import torch_xla
+from torch.utils._pytree import tree_iter
 
 from functorch.compile import aot_function, make_boxed_func  # type:ignore
 from .remat_all import remat_all_partition_fn
@@ -48,9 +49,10 @@ def remat_all_and_offload_these_inputs(
   specified names to host memory, moving them back during the backward pass.
   It transforms the joint graph into separate forward and backward graphs.
   """
+  input_device = next(iter(tree_iter(_joint_inputs))).device
   fwd, bwd = remat_all_partition_fn(
       joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs)
-  with torch.device('meta'):
+  with torch.device(input_device):
     fw_example_args = make_arguments(fwd)
     bw_example_args = make_arguments(bwd)
 

--- a/src/transformers/models/llama/graph_transforms/remat_all.py
+++ b/src/transformers/models/llama/graph_transforms/remat_all.py
@@ -1,0 +1,75 @@
+import torch.fx
+import torch._functorch.config
+from functorch.compile import min_cut_rematerialization_partition
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def remat_all_config():
+  # Backup existing config values
+  backup = {
+      "activation_memory_budget":
+          torch._functorch.config.activation_memory_budget,
+      "aggressive_recomputation":
+          torch._functorch.config.aggressive_recomputation,
+      "recompute_views":
+          torch._functorch.config.recompute_views,
+      "ban_recompute_reductions":
+          torch._functorch.config.ban_recompute_reductions,
+      "ban_recompute_not_in_allowlist":
+          torch._functorch.config.ban_recompute_not_in_allowlist,
+      "ban_recompute_materialized_backward":
+          torch._functorch.config.ban_recompute_materialized_backward,
+      "ban_recompute_long_fusible_chains":
+          torch._functorch.config.ban_recompute_long_fusible_chains,
+      "ban_recompute_used_far_apart":
+          torch._functorch.config.ban_recompute_used_far_apart,
+  }
+
+  try:
+    # Set activation_memory_budget to zero to force the min cut partitioner
+    # to recompute instead of saving. Also don't ban the recomputing of any ops.
+    torch._functorch.config.activation_memory_budget = 0.0
+    torch._functorch.config.aggressive_recomputation = True
+    torch._functorch.config.recompute_views = True
+    torch._functorch.config.ban_recompute_reductions = False
+    torch._functorch.config.ban_recompute_not_in_allowlist = False
+    torch._functorch.config.ban_recompute_materialized_backward = False
+    torch._functorch.config.ban_recompute_long_fusible_chains = False
+    torch._functorch.config.ban_recompute_used_far_apart = False
+    yield
+
+  finally:
+    # Restore the original config values
+    torch._functorch.config.activation_memory_budget = backup[
+        "activation_memory_budget"]
+    torch._functorch.config.aggressive_recomputation = backup[
+        "aggressive_recomputation"]
+    torch._functorch.config.recompute_views = backup["recompute_views"]
+    torch._functorch.config.ban_recompute_reductions = backup[
+        "ban_recompute_reductions"]
+    torch._functorch.config.ban_recompute_not_in_allowlist = backup[
+        "ban_recompute_not_in_allowlist"]
+    torch._functorch.config.ban_recompute_materialized_backward = backup[
+        "ban_recompute_materialized_backward"]
+    torch._functorch.config.ban_recompute_long_fusible_chains = backup[
+        "ban_recompute_long_fusible_chains"]
+    torch._functorch.config.ban_recompute_used_far_apart = backup[
+        "ban_recompute_used_far_apart"]
+
+
+def remat_all_partition_fn(
+    joint_module: torch.fx.GraphModule,
+    _joint_inputs,
+    *,
+    num_fwd_outputs,
+):
+  """
+  remat_all_partition_fn is a graph partition function that closely matches the
+  default behavior of `torch.utils.checkpoint`, which is to discard all intermediate
+  activations and recompute all of them during the backward pass.
+  """
+  with remat_all_config():
+    return min_cut_rematerialization_partition(
+        joint_module, _joint_inputs, num_fwd_outputs=num_fwd_outputs)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1292,7 +1292,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
             logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
             spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
-            torch_xla.distributed.spmd.mark_sharding(logits, spmd_mesh, (('fsdp', 'tensor'), None, None))
+            torch_xla.distributed.spmd.mark_sharding(logits, spmd_mesh, ('fsdp', None, 'tensor'))
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1291,6 +1291,8 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         else:
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
             logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+            spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
+            torch_xla.distributed.spmd.mark_sharding(logits, spmd_mesh, (('fsdp', 'tensor'), None, None))
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -63,6 +63,7 @@ if is_flash_attn_2_available():
 
 import torch_xla.debug.profiler as xp
 from torch_xla.distributed.spmd.xla_sharding import XLAPatchedLinear, xla_patched_nn_linear_forward
+import torch_xla.distributed.spmd
 
 logger = logging.get_logger(__name__)
 
@@ -954,6 +955,9 @@ class LlamaModel(LlamaPreTrainedModel):
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False
+            
+        spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
+        torch_xla.distributed.spmd.mark_sharding(input_ids, spmd_mesh, ('fsdp', None))
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -956,8 +956,8 @@ class LlamaModel(LlamaPreTrainedModel):
             )
             use_cache = False
             
-        spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
-        torch_xla.distributed.spmd.mark_sharding(input_ids, spmd_mesh, ('fsdp', None))
+        # spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
+        # torch_xla.distributed.spmd.mark_sharding(input_ids, spmd_mesh, ('fsdp', None))
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -1291,11 +1291,12 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
         else:
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
             logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
-            spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
-            torch_xla.distributed.spmd.mark_sharding(logits, spmd_mesh, ('fsdp', None, 'tensor'))
+            # spmd_mesh = torch_xla.distributed.spmd.get_global_mesh()
+            # torch_xla.distributed.spmd.mark_sharding(logits, spmd_mesh, ('fsdp', None, 'tensor'))
 
         loss = None
         if labels is not None:
+            # torch_xla.distributed.spmd.mark_sharding(labels, spmd_mesh, ('fsdp', None))
             # Upcast to float if we need to compute the loss to avoid potential precision issues
             logits = logits.float()
             # Shift so that tokens < n predict n

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1004,7 +1004,7 @@ class LlamaModel(LlamaPreTrainedModel):
                     return hidden_states
 
             curried_layers = [ CurriedLayer(l, position_embeddings, causal_mask) for l in self.layers ]
-            hidden_states = scan_layers(curried_layers, hidden_states, partition_fn=remat_all_partition_fn)
+            hidden_states = scan_layers(curried_layers, hidden_states, partition_fn=remat_all_offload_decoder_input)
         else:
             self.log_once("NOTE: Using for loop to run decoder layers")
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -128,7 +128,7 @@ class LlamaRotaryEmbedding(nn.Module):
         self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device, **self.rope_kwargs)
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("inv_freq", inv_freq, persistent=True)
         self.original_inv_freq = self.inv_freq
 
     def _dynamic_frequency_update(self, position_ids, device):
@@ -142,11 +142,11 @@ class LlamaRotaryEmbedding(nn.Module):
             inv_freq, self.attention_scaling = self.rope_init_fn(
                 self.config, device, seq_len=seq_len, **self.rope_kwargs
             )
-            self.register_buffer("inv_freq", inv_freq, persistent=False)  # TODO joao: may break with compilation
+            self.register_buffer("inv_freq", inv_freq, persistent=True)  # TODO joao: may break with compilation
             self.max_seq_len_cached = seq_len
 
         if seq_len < self.original_max_seq_len and self.max_seq_len_cached > self.original_max_seq_len:  # reset
-            self.register_buffer("inv_freq", self.original_inv_freq, persistent=False)
+            self.register_buffer("inv_freq", self.original_inv_freq, persistent=True)
             self.max_seq_len_cached = self.original_max_seq_len
 
     @torch.no_grad()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3584,6 +3584,9 @@ class Trainer:
                 torch.cuda.empty_cache()
 
         kwargs = {}
+        
+        # Set a debug env var to find unexpected transfers to device.
+        os.environ["DEBUG_TRANSFER_IR_VALUE_TENSOR_TO_XLA_DATA"] = "1"
 
         # For LOMO optimizers you need to explicitly use the learnign rate
         if self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
@@ -3598,6 +3601,8 @@ class Trainer:
         else:
             with xp.Trace('backward'):
                 self.accelerator.backward(loss, **kwargs)
+                
+        del os.environ["DEBUG_TRANSFER_IR_VALUE_TENSOR_TO_XLA_DATA"]
 
         return loss.detach() / self.args.gradient_accumulation_steps
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2565,7 +2565,8 @@ class Trainer:
                 )
                 self.control.should_training_stop = True
                 
-            del os.environ["DEBUG_LARGE_TRANSFER"]
+            if "DEBUG_LARGE_TRANSFER" in os.environ:
+                del os.environ["DEBUG_LARGE_TRANSFER"]
 
             self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
             self._maybe_log_save_evaluate(tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2546,8 +2546,10 @@ class Trainer:
                     # Wait until device execution catches up to tracing before triggering the profile. This will
                     # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
                     # for the step, the interruption will be minimal.
+                    print("About to start profiling. Wait for device execution to catch up first.", flush=True)
                     xm.wait_device_ops()
                     import tempfile
+                    print("Starting profiling...", flush=True)
                     xp.trace_detached('127.0.0.1:9012', profile_logdir or tempfile.mkdtemp(), profile_duration or 20000)
 
                 if self.control.should_epoch_stop or self.control.should_training_stop:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2559,6 +2559,11 @@ class Trainer:
                     if is_torch_xla_available():
                         xm.mark_step()
                     break
+                
+                # HACK: debug megascale hanging
+                print("Wait device ops", flush=True)
+                torch_xla.sync(wait=True)
+                xm.wait_device_ops()
             if step < 0:
                 logger.warning(
                     "There seems not to be a single sample in your epoch_iterator, stopping training at step"

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2452,7 +2452,8 @@ class Trainer:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
                 with self.accelerator.accumulate(model):
-                    tr_loss_step = self.training_step(model, inputs)
+                    with xp.Trace('loss_and_grad'):
+                        tr_loss_step = self.training_step(model, inputs)
 
                 if (
                     args.logging_nan_inf_filter
@@ -2516,7 +2517,8 @@ class Trainer:
 
                     self.control = self.callback_handler.on_pre_optimizer_step(args, self.state, self.control)
 
-                    self.optimizer.step()
+                    with xp.Trace('optimizer'):
+                        self.optimizer.step()
 
                     self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
 
@@ -2526,7 +2528,8 @@ class Trainer:
                         if not isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
                             self.lr_scheduler.step()
 
-                    model.zero_grad()
+                    with xp.Trace('zero_grad'):
+                        model.zero_grad()
                     self.state.global_step += 1
                     self.state.epoch = epoch + (step + 1 + steps_skipped) / steps_in_epoch
                     self.control = self.callback_handler.on_step_end(args, self.state, self.control)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3561,6 +3561,9 @@ class Trainer:
         if is_sagemaker_mp_enabled():
             loss_mb = smp_forward_backward(model, inputs, self.args.gradient_accumulation_steps)
             return loss_mb.reduce_mean().detach().to(self.args.device)
+        
+        # Set a debug env var to find unexpected transfers to device.
+        os.environ["DEBUG_TRANSFER_IR_VALUE_TENSOR_TO_XLA_DATA"] = "1"
 
         with self.compute_loss_context_manager():
             loss = self.compute_loss(model, inputs)
@@ -3585,9 +3588,6 @@ class Trainer:
 
         kwargs = {}
         
-        # Set a debug env var to find unexpected transfers to device.
-        os.environ["DEBUG_TRANSFER_IR_VALUE_TENSOR_TO_XLA_DATA"] = "1"
-
         # For LOMO optimizers you need to explicitly use the learnign rate
         if self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
             kwargs["learning_rate"] = self._get_learning_rate()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -36,6 +36,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
+import torch_xla
+import torch_xla.debug.profiler as xp
+
 
 # Integrations must be imported before ML frameworks:
 # isort: off
@@ -3593,7 +3596,8 @@ class Trainer:
             with amp.scale_loss(loss, self.optimizer) as scaled_loss:
                 scaled_loss.backward()
         else:
-            self.accelerator.backward(loss, **kwargs)
+            with xp.Trace('backward'):
+                self.accelerator.backward(loss, **kwargs)
 
         return loss.detach() / self.args.gradient_accumulation_steps
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2559,11 +2559,6 @@ class Trainer:
                     if is_torch_xla_available():
                         xm.mark_step()
                     break
-                
-                # HACK: debug megascale hanging
-                print("Wait device ops", flush=True)
-                torch_xla.sync(wait=True)
-                xm.wait_device_ops()
             if step < 0:
                 logger.warning(
                     "There seems not to be a single sample in your epoch_iterator, stopping training at step"

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -25,7 +25,7 @@ mkdir -p xla_dumps/scan-offload-ptxla
 export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
 export PROFILE_EPOCH=0
-export PROFILE_STEP=1
+export PROFILE_STEP=4
 export PROFILE_DURATION_MS=20000
 export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
 

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -76,7 +76,7 @@ BLOCK_SIZE=8192
 python3 examples/pytorch/language-modeling/run_clm.py \
   --dataset_name wikitext \
   --dataset_config_name wikitext-103-raw-v1 \
-  --per_device_train_batch_size 8 \
+  --per_device_train_batch_size 16 \
   --do_train \
   --output_dir /workspaces/torch/output/test-clm \
   --overwrite_output_dir \
@@ -91,7 +91,7 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --dataloader_drop_last yes \
   --flash_attention \
   --spmd_2d_sharding 2 \
-  --max_steps 50
+  --max_steps 20
 
 #  --spmd_2d_sharding 2 \
 #  --fsdp "full_shard" \

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -91,7 +91,7 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --torch_dtype bfloat16 \
   --dataloader_drop_last yes \
   --spmd_2d_sharding 2 \
-  --max_steps 10 $EXTRA
+  --max_steps 100 $EXTRA
 
 
 #  --fsdp "full_shard" \

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -26,7 +26,7 @@ export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
 export PROFILE_EPOCH=0
 export PROFILE_STEP=4
-export PROFILE_DURATION_MS=10000
+export PROFILE_DURATION_MS=20000
 export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
 
 mkdir -p /workspaces/torch/profile/scan-offload-ptxla

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -35,9 +35,6 @@ export XLA_SAVE_TENSORS_FILE=ir_dumps/scan-offload-ptxla.txt
 export XLA_SAVE_TENSORS_FMT=hlo
 export XLA_FLAGS=--xla_dump_to=xla_dumps/scan-offload-ptxla
 
-BLOCK_SIZE=8192
-EXTRA='--flash_attention'
-
 cat << EOF > /workspaces/torch/model_config.json
 {
     "architectures": [
@@ -68,6 +65,8 @@ cat << EOF > /workspaces/torch/model_config.json
 }
 EOF
 
+BLOCK_SIZE=8192
+
 # Debugging notes:
 # set print object on
 # set print vtbl on
@@ -90,9 +89,10 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --logging_strategy no \
   --torch_dtype bfloat16 \
   --dataloader_drop_last yes \
+  --flash_attention \
   --spmd_2d_sharding 2 \
-  --max_steps 100 $EXTRA
+  --max_steps 50
 
-
+#  --spmd_2d_sharding 2 \
 #  --fsdp "full_shard" \
 #  --fsdp_config fsdp_config.json \

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -91,7 +91,7 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --torch_dtype bfloat16 \
   --dataloader_drop_last yes \
   --spmd_2d_sharding 2 \
-  --max_steps 1000 $EXTRA
+  --max_steps 10 $EXTRA
 
 
 #  --fsdp "full_shard" \

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -14,12 +14,19 @@ mkdir -p xla_dumps/scan-offload-ptxla
 
 export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
+export PROFILE_EPOCH=0
+export PROFILE_STEP=4
+export PROFILE_DURATION_MS=120000
+export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
+
+mkdir -p /workspaces/torch/profile/scan-offload-ptxla
 
 export XLA_SAVE_TENSORS_FILE=ir_dumps/scan-offload-ptxla.txt
 export XLA_SAVE_TENSORS_FMT=hlo
 export XLA_FLAGS=--xla_dump_to=xla_dumps/scan-offload-ptxla
 
-BLOCK_SIZE=4096
+# BLOCK_SIZE=4096
+BLOCK_SIZE=2048
 EXTRA='--flash_attention'
 
 # Debugging notes:

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -26,7 +26,7 @@ export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
 export PROFILE_EPOCH=0
 export PROFILE_STEP=4
-export PROFILE_DURATION_MS=120000
+export PROFILE_DURATION_MS=30000
 export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
 
 mkdir -p /workspaces/torch/profile/scan-offload-ptxla

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -25,7 +25,7 @@ mkdir -p xla_dumps/scan-offload-ptxla
 export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
 export PROFILE_EPOCH=0
-export PROFILE_STEP=4
+export PROFILE_STEP=1
 export PROFILE_DURATION_MS=20000
 export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
 

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -35,7 +35,7 @@ export XLA_SAVE_TENSORS_FILE=ir_dumps/scan-offload-ptxla.txt
 export XLA_SAVE_TENSORS_FMT=hlo
 export XLA_FLAGS=--xla_dump_to=xla_dumps/scan-offload-ptxla
 
-BLOCK_SIZE=4096
+BLOCK_SIZE=8192
 EXTRA='--flash_attention'
 
 cat << EOF > /workspaces/torch/model_config.json
@@ -91,4 +91,4 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --torch_dtype bfloat16 \
   --dataloader_drop_last yes \
   --spmd_2d_sharding 2 \
-  --max_steps 500 $EXTRA
+  --max_steps 1000 $EXTRA

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -26,7 +26,7 @@ export XLA_IR_DEBUG=1
 export XLA_HLO_DEBUG=1
 export PROFILE_EPOCH=0
 export PROFILE_STEP=4
-export PROFILE_DURATION_MS=30000
+export PROFILE_DURATION_MS=10000
 export PROFILE_LOGDIR=/workspaces/torch/profile/scan-offload-ptxla
 
 mkdir -p /workspaces/torch/profile/scan-offload-ptxla

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -77,7 +77,7 @@ EOF
 python3 examples/pytorch/language-modeling/run_clm.py \
   --dataset_name wikitext \
   --dataset_config_name wikitext-103-raw-v1 \
-  --per_device_train_batch_size 16 \
+  --per_device_train_batch_size 8 \
   --do_train \
   --output_dir /workspaces/torch/output/test-clm \
   --overwrite_output_dir \
@@ -92,3 +92,7 @@ python3 examples/pytorch/language-modeling/run_clm.py \
   --dataloader_drop_last yes \
   --spmd_2d_sharding 2 \
   --max_steps 1000 $EXTRA
+
+
+#  --fsdp "full_shard" \
+#  --fsdp_config fsdp_config.json \

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -1,0 +1,48 @@
+set -exo
+
+export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_decompose_all_gather_einsum=true --xla_tpu_decompose_einsum_reduce_scatter=true --xla_tpu_scoped_vmem_limit_kib=98304 --xla_tpu_spmd_rng_bit_generator_unsafe=true --xla_tpu_overlap_compute_collective_tc=true --xla_tpu_use_enhanced_launch_barrier=true --xla_tpu_enable_all_experimental_scheduler_features=true --xla_tpu_enable_scheduler_memory_pressure_tracking=true --xla_tpu_host_transfer_overlap_limit=2 --xla_tpu_aggressive_opt_barrier_removal=ENABLED --xla_lhs_prioritize_async_depth_over_stall=ENABLED --xla_tpu_enable_ag_backward_pipelining=true --xla_should_allow_loop_variant_parameter_in_chain=ENABLED --xla_should_add_loop_invariant_op_in_chain=ENABLED --xla_max_concurrent_host_send_recv=100 --xla_tpu_scheduler_percent_shared_memory_limit=100 --xla_latency_hiding_scheduler_rerun=2"
+
+export PJRT_DEVICE=TPU
+export XLA_USE_SPMD=1
+
+mkdir -p profile
+mkdir -p ir_dumps
+mkdir -p xla_dumps
+rm ir_dumps/scan-offload-ptxla.txt.* || true
+rm -rf xla_dumps/scan-offload-ptxla || true
+mkdir -p xla_dumps/scan-offload-ptxla
+
+export XLA_IR_DEBUG=1
+export XLA_HLO_DEBUG=1
+
+export XLA_SAVE_TENSORS_FILE=ir_dumps/scan-offload-ptxla.txt
+export XLA_SAVE_TENSORS_FMT=hlo
+export XLA_FLAGS=--xla_dump_to=xla_dumps/scan-offload-ptxla
+
+BLOCK_SIZE=4096
+EXTRA='--flash_attention'
+
+# Debugging notes:
+# set print object on
+# set print vtbl on
+# b aten_xla_bridge.cpp:116
+# set substitute-path torch_xla/csrc /workspaces/torch/pytorch/xla/torch_xla/csrc
+# gdb --args python3 examples/pytorch/language-modeling/run_clm.py \
+python3 examples/pytorch/language-modeling/run_clm.py \
+  --dataset_name wikitext \
+  --dataset_config_name wikitext-103-raw-v1 \
+  --per_device_train_batch_size 8 \
+  --do_train \
+  --output_dir /workspaces/torch/output/test-clm \
+  --overwrite_output_dir \
+  --config_name /workspaces/torch/config.json \
+  --cache_dir /workspaces/torch/cache \
+  --tokenizer_name meta-llama/Llama-2-7b-hf \
+  --block_size $BLOCK_SIZE \
+  --optim adafactor \
+  --save_strategy no \
+  --logging_strategy no \
+  --torch_dtype bfloat16 \
+  --dataloader_drop_last yes \
+  --spmd_2d_sharding 2 \
+  --max_steps 500 $EXTRA

--- a/test_offload.sh
+++ b/test_offload.sh
@@ -77,7 +77,7 @@ EOF
 python3 examples/pytorch/language-modeling/run_clm.py \
   --dataset_name wikitext \
   --dataset_config_name wikitext-103-raw-v1 \
-  --per_device_train_batch_size 8 \
+  --per_device_train_batch_size 16 \
   --do_train \
   --output_dir /workspaces/torch/output/test-clm \
   --overwrite_output_dir \


### PR DESCRIPTION
# What does this PR do?

These are the changes to make Llama 3.1 405B work on two Trillium TPU pods. It includes:

- Initialize the model layer by layer on the CPU, to workaround an OOM bug when initializing all layers in the model at once on the TPU.
- Save the `inv_freq` buffer in Llama for now, to ensure we can initialize it using `load_state_dict`. Otherwise, the `inv_freq` buffer will stay as a meta tensor.
- Adds a `USE_SINGLE_SLICE` env var before importing jax, to prevent jax from re-initializing MegaScale client. A corresponding custom libtpu build is required.
- Use a custom hybrid ring mesh to improve collectives performance.
